### PR TITLE
App Insights to output AppId

### DIFF
--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -32,6 +32,10 @@
         "InstrumentationKey": {
             "type": "string",
             "value": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).InstrumentationKey]"
+        },
+        "AppId": {
+            "type": "string",
+            "value": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).AppId]"
         }
     }
 }


### PR DESCRIPTION
Adds AppId (required for annotation using the API) to the App Insight template outputs