### PR TITLE
Update api version to 2018-11-01

### DIFF
--- a/templates/app-service.json
+++ b/templates/app-service.json
@@ -54,7 +54,7 @@
         {
             "name": "[parameters('appServiceName')]",
             "type": "Microsoft.Web/sites",
-            "apiVersion": "2016-08-01",
+            "apiVersion": "2018-11-01",
             "location": "[resourceGroup().location]",
             "properties": {
                 "serverFarmId": "[variables('appServicePlanId')]",
@@ -72,7 +72,7 @@
                     "condition": "[parameters('deployStagingSlot')]",
                     "name": "staging",
                     "type": "slots",
-                    "apiVersion": "2016-08-01",
+                    "apiVersion": "2018-11-01",
                     "location": "[resourceGroup().location]",
                     "properties": {
                         "clientAffinityEnabled": false,
@@ -93,7 +93,7 @@
             "type": "Microsoft.Web/sites/hostnameBindings",
             "condition": "[variables('UseCustomHostname')]",
             "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
-            "apiVersion": "2016-08-01",
+            "apiVersion": "2018-11-01",
             "location": "[resourceGroup().location]",
             "properties": {
                 "sslState": "SniEnabled",


### PR DESCRIPTION
To use the latest networking features available in App Service we need to ensure that we are using the correct API version.

2018-11-01 has the vnent integration property available and is also the latest version listed in the reference site.

https://docs.microsoft.com/en-us/azure/templates/microsoft.web/2018-11-01/sites#ipsecurityrestriction-object