### PR TITLE
Removed appServiceLocation parameter

### DIFF
--- a/templates/app-service.json
+++ b/templates/app-service.json
@@ -5,10 +5,6 @@
     "appServiceName": {
       "type": "string"
     },
-    "appServiceLocation": {
-      "type": "string",
-      "defaultValue": "[resourceGroup().location]"
-    },
     "appServicePlanName": {
       "type": "string"
     },
@@ -113,7 +109,7 @@
       "type": "Microsoft.Web/sites",
       "kind": "[parameters('appKind')]",
       "apiVersion": "2018-11-01",
-      "location": "[parameters('appServiceLocation')]",
+      "location": "[resourceGroup().location]",
       "properties": {
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
@@ -132,7 +128,7 @@
           "name": "staging",
           "type": "slots",
           "apiVersion": "2018-11-01",
-          "location": "[parameters('appServiceLocation')]",
+          "location": "[resourceGroup().location]",
           "properties": {
             "clientAffinityEnabled": false,
             "siteConfig": {
@@ -167,7 +163,7 @@
       "condition": "[variables('UseCustomHostname')]",
       "name": "[concat(parameters('appServiceName'), '/', if(variables('useCustomHostname'), parameters('customHostname'), 'placeholder'))]",
       "apiVersion": "2018-11-01",
-      "location": "[parameters('appServiceLocation')]",
+      "location": "[resourceGroup().location]",
       "properties": {
         "sslState": "SniEnabled",
         "thumbprint": "[parameters('certificateThumbprint')]"


### PR DESCRIPTION
Reverted addition of appServiceLocation parameter.
Location of resource group is used in the template as before, following migration of a resource group.