### PR TITLE
Fix storage container default public access

### DIFF
--- a/templates/storage-container.json
+++ b/templates/storage-container.json
@@ -16,7 +16,7 @@
     },
     "publicAccess": {
       "type": "string",
-      "defaultValue": "none",
+      "defaultValue": "None",
       "allowedValues": [
         "Container",
         "Blob",


### PR DESCRIPTION
Resolves the following error
`Error: Code=InvalidTemplate; Message=Deployment template validation failed: 'The provided value 'none' for the template parameter 'publicAccess' at line '17' and column '21' is not valid. The parameter value is not part of the allowed value(s): 'Container,Blob,None'.'.`