### PR TITLE
Update api version for master database deployment

### DIFF
--- a/templates/sql-server.json
+++ b/templates/sql-server.json
@@ -92,7 +92,7 @@
       "resources": [
         {
           "type": "databases",
-          "apiVersion": "2014-04-01",
+          "apiVersion": "2017-10-01-preview",
           "location": "[parameters('sqlServerLocation')]",
           "name": "master",
           "properties": {},


### PR DESCRIPTION
Resolves the following error on deployment:
`'System' is not a valid database edition in this version of SQL Server.`