### PR TITLE
Adds system assigned identity

### DIFF
--- a/templates/app-service.json
+++ b/templates/app-service.json
@@ -110,6 +110,9 @@
       "kind": "[parameters('appKind')]",
       "apiVersion": "2018-11-01",
       "location": "[resourceGroup().location]",
+      "identity": {
+        "type": "SystemAssigned"
+      },
       "properties": {
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
@@ -129,6 +132,9 @@
           "type": "slots",
           "apiVersion": "2018-11-01",
           "location": "[resourceGroup().location]",
+          "identity": {
+            "type": "SystemAssigned"
+          },
           "properties": {
             "clientAffinityEnabled": false,
             "siteConfig": {


### PR DESCRIPTION
This PR adds a system assigned identity to app services and their associated slot (if deployed).

The change should have no impact on current deployments but will allow us to make use of the feature in the future.