### PR TITLE
Added ip Range Filter

### DIFF
--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -29,6 +29,10 @@
     "subnetResourceIdList": {
       "type": "array",
       "defaultValue": []
+    },
+    "ipRangeFilter": {
+      "type": "string",
+      "defaultValue": ""
     }
   },
   "variables": {
@@ -56,6 +60,7 @@
           "defaultConsistencyLevel": "[parameters('defaultConsistencyLevel')]"
         },
         "databaseAccountOfferType": "Standard",
+        "ipRangeFilter": "[parameters('ipRangeFilter')]",
         "isVirtualNetworkFilterEnabled": "[if(greater(length(variables('virtualNetworkRules')), 0), bool('true'), bool('false'))]",
         "virtualNetworkRules": "[variables('virtualNetworkRules')]"
       }


### PR DESCRIPTION
Added ipRangeFilter which allows to pre-populate the cosmos firewall so it is not overwritten each release. Default value of empty string has been tested to ensure the change is none breaking.