### PR TITLE
Add storagePrimaryEndpointsBlob output to storage-account-arm.json template

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -168,6 +168,10 @@
     "storageConnectionString": {
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('storageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
+    },
+    "storageBlobPrimaryEndpoint": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
     }
   }
 }

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -169,7 +169,7 @@
       "type": "string",
       "value": "[concat('DefaultEndpointsProtocol=https;AccountName=',parameters('storageAccountName'),';AccountKey=',listKeys(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).keys[0].value, ';EndpointSuffix=core.windows.net')]"
     },
-    "storageBlobPrimaryEndpoint": {
+    "storagePrimaryEndpointsBlob": {
       "type": "string",
       "value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
     }

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -171,7 +171,7 @@
     },
     "storagePrimaryEndpointsBlob": {
       "type": "string",
-      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), providers('Microsoft.Storage', 'storageAccounts').apiVersions[0]).primaryEndpoints.blob]"
+      "value": "[reference(resourceId('Microsoft.Storage/storageAccounts',parameters('storageAccountName')), '2019-04-01').primaryEndpoints.blob]"
     }
   }
 }


### PR DESCRIPTION
This allows parent ARM templates to return the value of the primary blob endpoint for storage account linked template deployments. Requirement comes from das-qna-api pipeline where the primary blob endpoint is required to be passed in as a SqlPackage variable into the DACPAC task so that it can be used to read data from the blob container.