### PR TITLE
Updated function-app.json and adding new consumption-plan.json

### DIFF
--- a/templates/consumption-plan.json
+++ b/templates/consumption-plan.json
@@ -18,6 +18,9 @@
     "sku": {
       "name": "Y1",
       "tier": "Dynamic"
+    },
+    "properties": {
+      "name": "[parameters('consumptionPlanName')]"
     }
   },
   "resources": [
@@ -26,7 +29,8 @@
       "apiVersion": "2016-09-01",
       "name": "[parameters('consumptionPlanName')]",
       "location": "[parameters('consumptionPlanLocation')]",
-      "sku": "[variables('sku')]"
+      "sku": "[variables('sku')]",
+      "properties": "[variables('properties')]"
     }
   ],
   "outputs": {

--- a/templates/consumption-plan.json
+++ b/templates/consumption-plan.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "consumptionPlanName": {
+      "type": "string"
+    },
+    "consumptionPlanLocation": {
+      "type": "string",
+      "allowedValues": [
+        "North Europe",
+        "West Europe"
+      ],
+      "defaultValue": "West Europe"
+    }
+  },
+  "variables": {
+    "sku": {
+      "name": "Y1",
+      "tier": "Dynamic"
+    }
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/serverfarms",
+      "apiVersion": "2016-09-01",
+      "name": "[parameters('consumptionPlanName')]",
+      "location": "[parameters('consumptionPlanLocation')]",
+      "sku": "[variables('sku')]"
+    }
+  ],
+  "outputs": {
+    "ConsumptionPlanName": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Web/serverfarms', parameters('consumptionPlanName'))]"
+    }
+  }
+}

--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -53,7 +53,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
         "siteConfig": {
-          "alwaysOn": "[if(equals(reference(resourceId('Microsoft.Web/serverFarms',parameters('appServicePlanName')), '2019-08-01').computeMode,'Dynamic'), 'true', 'false')]",
+          "alwaysOn": "[if(equals(reference(resourceId('Microsoft.Web/serverFarms',parameters('appServicePlanName')), '2019-08-01').computeMode,'Dynamic'), 'false', 'true')]",
           "appSettings": "[parameters('functionAppAppSettings')]",
           "connectionStrings": "[parameters('functionAppConnectionStrings')]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]"

--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -53,7 +53,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
         "siteConfig": {
-          "alwaysOn": true,
+          "alwaysOn": "[if(equals(reference(resourceId('Microsoft.Web/serverFarms',parameters('appServicePlanName')), '2019-08-01').computeMode,'Dynamic'), 'true', 'false')]",
           "appSettings": "[parameters('functionAppAppSettings')]",
           "connectionStrings": "[parameters('functionAppConnectionStrings')]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]"


### PR DESCRIPTION
- Updated `function-app.json` to check whether the App Service Plan is a Consumption Plan by checking the `computeMode`. If it's `Dynamic` which refers to a Consumption Plan type, then set `AlwaysOn` to `false`, otherwise set to `true`. If this is not set to false, then the Function App cannot be deployed onto a Consumption Plan.
- Adding new building block `consumption-plan.json`. A Consumption Plan is very specific with just ` SKU name `Y1` and tier `Dynamic` required. The `app-service-plan.json` file already has some logic relating to ASE and non-ase and I think trying to perform more logic to deploy a Consumption Plan using the existing `app-service-plan.json` might make it unreadable and messy. 