### PR TITLE
Added parameters('appServicePlanResourceGroup') to alwaysOn if statement

### DIFF
--- a/templates/function-app.json
+++ b/templates/function-app.json
@@ -53,7 +53,7 @@
         "serverFarmId": "[variables('appServicePlanId')]",
         "clientAffinityEnabled": false,
         "siteConfig": {
-          "alwaysOn": "[if(equals(reference(resourceId('Microsoft.Web/serverFarms',parameters('appServicePlanName')), '2019-08-01').computeMode,'Dynamic'), 'false', 'true')]",
+          "alwaysOn": "[if(equals(reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Web/serverFarms',parameters('appServicePlanName')), '2019-08-01').computeMode,'Dynamic'), 'false', 'true')]",
           "appSettings": "[parameters('functionAppAppSettings')]",
           "connectionStrings": "[parameters('functionAppConnectionStrings')]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]"


### PR DESCRIPTION
The alwaysOn if statement resourceId didn't take into account whether the ASP was in a different resource group, i.e. shared ASP. It would look in the resource group of the deployment, this should now look at the resource group name passed in as parameter `appServicePlanResourceGroup`. 