### PR TITLE
Enforce common alert schema for webhooks

### DIFF
--- a/templates/action-group.json
+++ b/templates/action-group.json
@@ -44,7 +44,8 @@
         "webhookReceivers": [
           {
             "name": "[parameters('webhookReceiverName')]",
-            "serviceUri": "[parameters('webhookServiceUri')]"
+            "serviceUri": "[parameters('webhookServiceUri')]",
+            "useCommonAlertSchema": true
           }
         ]
       }


### PR DESCRIPTION
Ensure that the common alert schema is always used for webhook action groups