### PR TITLE
Adding storage-management-policy.json

### DIFF
--- a/templates/storage-management-policy.json
+++ b/templates/storage-management-policy.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "storageAccountName": {

--- a/templates/storage-management-policy.json
+++ b/templates/storage-management-policy.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "storageAccountName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the storage account"
+      }
+    },
+    "policyRules": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of management policy rules"
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "name": "[concat(parameters('storageAccountName'), '/default')]",
+      "type": "Microsoft.Storage/storageAccounts/managementPolicies",
+      "apiVersion": "2019-04-01",
+      "properties": {
+        "policy": {
+          "rules": "[parameters('policyRules')]"
+        }
+      }
+    }
+  ],
+  "outputs": {}
+}

--- a/templates/storage-management-policy.json
+++ b/templates/storage-management-policy.json
@@ -12,7 +12,7 @@
       "type": "array",
       "defaultValue": [],
       "metadata": {
-        "description": "A list of management policy rules"
+        "description": "A list of management policy rules. See https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/2019-06-01/storageaccounts/managementpolicies#managementpolicyrule-object for required properties"
       }
     }
   },

--- a/templates/storage-management-policy.json
+++ b/templates/storage-management-policy.json
@@ -21,7 +21,7 @@
     {
       "name": "[concat(parameters('storageAccountName'), '/default')]",
       "type": "Microsoft.Storage/storageAccounts/managementPolicies",
-      "apiVersion": "2019-04-01",
+      "apiVersion": "2019-06-01",
       "properties": {
         "policy": {
           "rules": "[parameters('policyRules')]"


### PR DESCRIPTION
Adding new building block `storage-management-policy.json`. This will allow you to apply lifecycle management rules to Storage Accounts that are General Purpose v2.