### PR TITLE
Storage Account Creation should take into account IP Addresses as well as subnet Ids

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -98,8 +98,7 @@
     }
   },
   "variables": {
-    "networkAclObject": {
-      "bypass": "Logging, Metrics",
+    "virtualNetworkRules": {
       "copy": [
         {
           "name": "virtualNetworkRules",
@@ -108,7 +107,11 @@
             "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
             "action": "Allow"
           }
-        },
+        }
+      ]
+    },
+    "allowedIpRules": {
+      "copy": [
         {
           "name": "ipRules",
           "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
@@ -117,7 +120,12 @@
             "action": "Allow"
           }
         }
-      ],
+      ]
+    },
+    "networkAclObject": {
+      "bypass": "Logging, Metrics",
+      "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules'), json('null'))]",
+      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('null'))]",
       "defaultAction": "Deny"
     }
   },

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -125,7 +125,7 @@
     "networkAclObject": {
       "bypass": "Logging, Metrics",
       "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules'), json('null'))]",
-      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('null'))]",
+      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('[]'))]",
       "defaultAction": "Deny"
     }
   },

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -53,6 +53,13 @@
         "description": "A list of subnet resource ids."
       }
     },
+    "allowedIpAddresses": {
+      "type": "array",
+      "defaultValue": [],
+      "metadata": {
+        "description": "A list of allowed IPs"
+      }
+    },
     "enableCors": {
       "type": "string",
       "defaultValue": "False",
@@ -101,6 +108,14 @@
             "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
             "action": "Allow"
           }
+        },
+        {
+          "name": "ipRules",
+          "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
+          "input": {
+            "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('null'))]",
+            "action": "Allow"
+          }
         }
       ],
       "defaultAction": "Deny"
@@ -131,7 +146,7 @@
         },
         "accessTier": "[if(empty(parameters('accessTier')), json('null'), parameters('accessTier'))]",
         "supportsHttpsTrafficOnly": true,
-        "networkAcls": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddresses')), 0)), variables('networkAclObject'), json('null'))]"
       },
       "resources": [
           {

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -124,8 +124,24 @@
     },
     "networkAclObject": {
       "bypass": "Logging, Metrics",
-      "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules'), json('null'))]",
-      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('[]'))]",
+      "copy": [
+        {
+          "name": "virtualNetworkRules",
+          "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
+          "input": {
+            "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
+            "action": "Allow"
+          }
+        },
+        {
+          "name": "ipRules",
+          "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
+          "input": {
+            "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('[]'))]",
+            "action": "Allow"
+          }
+        }
+      ],
       "defaultAction": "Deny"
     }
   },

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -101,7 +101,6 @@
     "virtualNetworkRules": {
       "copy": [
         {
-          "name": "virtualNetworkRules",
           "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
           "input": {
             "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
@@ -113,7 +112,6 @@
     "allowedIpRules": {
       "copy": [
         {
-          "name": "ipRules",
           "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
           "input": {
             "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('null'))]",
@@ -124,24 +122,8 @@
     },
     "networkAclObject": {
       "bypass": "Logging, Metrics",
-      "copy": [
-        {
-          "name": "virtualNetworkRules",
-          "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
-          "input": {
-            "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
-            "action": "Allow"
-          }
-        },
-        {
-          "name": "ipRules",
-          "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
-          "input": {
-            "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('[]'))]",
-            "action": "Allow"
-          }
-        }
-      ],
+      "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules'), json('null'))]",
+      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('null'))]",
       "defaultAction": "Deny"
     }
   },

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -53,7 +53,7 @@
         "description": "A list of subnet resource ids."
       }
     },
-    "allowedIpAddresses": {
+    "allowedIpAddressesList": {
       "type": "array",
       "defaultValue": [],
       "metadata": {
@@ -110,13 +110,13 @@
         }
       ]
     },
-    "allowedIpRules": {
+    "ipRules": {
       "copy": [
         {
           "name": "ipRules",
-          "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
+          "count": "[if(greater(length(parameters('allowedIpAddressesList')), 0), length(parameters('allowedIpAddressesList')), 1)]",
           "input": {
-            "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('null'))]",
+            "value": "[if(greater(length(parameters('allowedIpAddressesList')), 0), parameters('allowedIpAddressesList')[copyIndex('ipRules')], json('null'))]",
             "action": "Allow"
           }
         }
@@ -125,7 +125,7 @@
     "networkAclObject": {
       "bypass": "Logging, Metrics",
       "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules').virtualNetworkRules, json('null'))]",
-      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules').ipRules, json('null'))]",
+      "ipRules": "[if(greater(length(parameters('allowedIpAddressesList')), 0), variables('ipRules').ipRules, json('null'))]",
       "defaultAction": "Deny"
     }
   },
@@ -154,7 +154,7 @@
         },
         "accessTier": "[if(empty(parameters('accessTier')), json('null'), parameters('accessTier'))]",
         "supportsHttpsTrafficOnly": true,
-        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddresses')), 0)), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
       },
       "resources": [
           {

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -101,6 +101,7 @@
     "virtualNetworkRules": {
       "copy": [
         {
+          "name": "virtualNetworkRules",
           "count": "[if(greater(length(parameters('subnetResourceIdList')), 0), length(parameters('subnetResourceIdList')), 1)]",
           "input": {
             "id": "[if(greater(length(parameters('subnetResourceIdList')), 0), parameters('subnetResourceIdList')[copyIndex('virtualNetworkRules')], json('null'))]",
@@ -112,6 +113,7 @@
     "allowedIpRules": {
       "copy": [
         {
+          "name": "ipRules",
           "count": "[if(greater(length(parameters('allowedIpAddresses')), 0), length(parameters('allowedIpAddresses')), 1)]",
           "input": {
             "value": "[if(greater(length(parameters('allowedIpAddresses')), 0), parameters('allowedIpAddresses')[copyIndex('ipRules')], json('null'))]",
@@ -122,8 +124,8 @@
     },
     "networkAclObject": {
       "bypass": "Logging, Metrics",
-      "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules'), json('null'))]",
-      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules'), json('null'))]",
+      "virtualNetworkRules": "[if(greater(length(parameters('subnetResourceIdList')), 0), variables('virtualNetworkRules').virtualNetworkRules, json('null'))]",
+      "ipRules": "[if(greater(length(parameters('allowedIpAddresses')), 0), variables('allowedIpRules').ipRules, json('null'))]",
       "defaultAction": "Deny"
     }
   },


### PR DESCRIPTION
Storage Account Creation should take into account IP Addresses as well as subnet Ids

This should allow neither, either or both to be passed in. 