### PR TITLE
DASD-8326 Add maxPods parameter

### DIFF
--- a/templates/aks-agent-pool.json
+++ b/templates/aks-agent-pool.json
@@ -66,6 +66,15 @@
         "nodeTaints": {
             "type": "array",
             "defaultValue": []
+        },
+        "maxPods": {
+            "type": "int",
+            "defaultValue": 30,
+            "metadata": {
+                "description": "The number of nodes for the cluster."
+            },
+            "minValue": 30,
+            "maxValue": 250
         }
     },
     "variables": {
@@ -85,7 +94,8 @@
                 "type": "VirtualMachineScaleSets",
                 "vnetSubnetID": "[variables('vnetSubnetId')]",
                 "orchestratorVersion": "[parameters('kubernetesVersion')]",
-                "nodeTaints": "[parameters('nodeTaints')]"
+                "nodeTaints": "[parameters('nodeTaints')]",
+                "maxPods": "[parameters('maxPods')]"
             }
         }
     ]

--- a/templates/aks-agent-pool.json
+++ b/templates/aks-agent-pool.json
@@ -71,7 +71,7 @@
             "type": "int",
             "defaultValue": 30,
             "metadata": {
-                "description": "The number of nodes for the cluster."
+                "description": "The maximum number of pods per node."
             },
             "minValue": 30,
             "maxValue": 250


### PR DESCRIPTION
- [ ] Prior to merging, any pipelines that consume this template should be checked to ensure they are deployed with the default maxPods value of 30. If they are not, we will need to override the maxPods parameter in the pipeline.