### PR TITLE
Updated WEBSITE_LOCAL_CACHE_SIZEINMB to 1000 from 300

### DIFF
--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -116,7 +116,7 @@
       },
       {
         "name": "WEBSITE_LOCAL_CACHE_SIZEINMB",
-        "value": "300"
+        "value": "1000"
       }
     ],
     "useCustomHostname": "[greater(length(parameters('customHostname')), 0)]",


### PR DESCRIPTION
Default app service local cache size has been updated from 300 MB to 1000 MB

https://docs.microsoft.com/en-us/azure/app-service/overview-local-cache#change-the-size-setting-in-local-cache