### PR TITLE
Added helm repo update to kubernetes-upgrade-helmchart.yml deploy step

### DIFF
--- a/azure-pipelines-templates/deploy/step/kubernetes-upgrade-helmchart.yml
+++ b/azure-pipelines-templates/deploy/step/kubernetes-upgrade-helmchart.yml
@@ -43,6 +43,15 @@ steps:
     command: repo
     arguments: add ${{ parameters.AdditionalChartRepoNameAndUrl }}
 - task: HelmDeploy@0
+  displayName: Helm repo update
+  inputs:
+    connectionType: Azure Resource Manager
+    azureSubscriptionEndpoint: ${{ parameters.AzureServiceConnection }}
+    azureResourceGroup: ${{ parameters.AksResourceGroupName }}
+    kubernetesCluster: ${{ parameters.AksClusterName }}
+    command: repo
+    arguments: update
+- task: HelmDeploy@0
   displayName: 'helm upgrade ${{ parameters.ChartName }}'
   inputs:
     azureSubscription: '${{ parameters.AzureServiceConnection }}'


### PR DESCRIPTION
Run `helm repo update` before attempting to run an upgrade to ensure latest chart information is downloaded if we ever need to upgrade the Grafana helm chart version.