### PR TITLE
Add minTlsVersion property and set to 1.2

### DIFF
--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -144,7 +144,8 @@
           "appSettings": "[variables('appServiceProductionSlotAppSettingsCombined')]",
           "connectionStrings": "[parameters('appServiceConnectionStrings').array]",
           "virtualApplications": "[parameters('appServiceVirtualApplications')]",
-          "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]"
+          "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
+          "minTlsVersion": "1.2"
         },
         "httpsOnly": true
       },
@@ -165,7 +166,8 @@
               "appSettings": "[if(variables('useAppServiceSlotAppSettings'), parameters('appServiceSlotAppSettings').array, parameters('appServiceAppSettings').array)]",
               "connectionStrings": "[if(variables('useAppServiceSlotConnectionStrings'), parameters('appServiceSlotConnectionStrings').array, parameters('appServiceConnectionStrings').array)]",
               "virtualApplications": "[parameters('appServiceVirtualApplications')]",
-              "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]"
+              "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
+              "minTlsVersion": "1.2"
             },
             "httpsOnly": true
           },

--- a/templates/function-app-v2.json
+++ b/templates/function-app-v2.json
@@ -79,7 +79,8 @@
           "appSettings": "[parameters('functionAppAppSettings').array]",
           "connectionStrings": "[parameters('functionAppConnectionStrings').array]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
-          "functionsRuntimeScaleMonitoringEnabled": "[parameters('runtimeScaleMonitoringEnabled')]"
+          "functionsRuntimeScaleMonitoringEnabled": "[parameters('runtimeScaleMonitoringEnabled')]",
+          "minTlsVersion": "1.2"
         },
         "httpsOnly": true
       }


### PR DESCRIPTION
Adding minTlsVersion property to the `app-service-v2.json` and `function-app-v2.json` templates. By default all new App Services are minimum 1.2 however this will ensure any legacy or any possible manual amendments to TLS settings are compliant.