### PR TITLE
DASD-9045: APIM templates: Replaced tenantPrimaryDomain parameter with tenantId, added signinTenant property

### DIFF
--- a/templates/apim/apim-group.json
+++ b/templates/apim/apim-group.json
@@ -5,7 +5,7 @@
     "apimName": {
       "type": "string"
     },
-    "tenantPrimaryDomain": {
+    "tenantId": {
       "type": "string"
     },
     "aadGroupObjectId": {
@@ -28,7 +28,7 @@
         "displayName": "[parameters('groupDisplayName')]",
         "description": "[parameters('groupDescription')]",
         "type": "external",
-        "externalId": "[concat('aad://', parameters('tenantPrimaryDomain'), '/groups/', parameters('aadGroupObjectId'))]"
+        "externalId": "[concat('aad://', parameters('tenantId'), '/groups/', parameters('aadGroupObjectId'))]"
       }
     }
   ],

--- a/templates/apim/apim-service-with-hostnames.json
+++ b/templates/apim/apim-service-with-hostnames.json
@@ -81,7 +81,7 @@
       "type": "string",
       "defaultValue": ""
     },
-    "tenantPrimaryDomain": {
+    "tenantId": {
       "type": "string"
     },
     "apimAppRegistrationClientId": {
@@ -143,8 +143,9 @@
       "apiVersion": "2019-12-01",
       "properties": {
         "type": "aad",
+        "signinTenant": "[parameters('tenantId')]",
         "allowedTenants": [
-          "[parameters('tenantPrimaryDomain')]"
+          "[parameters('tenantId')]"
         ],
         "authority": "login.windows.net",
         "clientId": "[parameters('apimAppRegistrationClientId')]",

--- a/templates/apim/apim-service.json
+++ b/templates/apim/apim-service.json
@@ -111,7 +111,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/DASD-9045-apim-dev-portal-tenant-id/templates/",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
     "deployCustomHostnames": "[and(greater(length(parameters('portalKeyVaultCertificateName')), 0), greater(length(parameters('gatewayKeyVaultCertificateName')), 0))]",
     "deployToNetwork": "[and(greater(length(parameters('virtualNetworkName')), 0), not(equals(parameters('virtualNetworkType'), 'None')))]",
     "subnetResourceId": "[concat(resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '/subnets/', parameters('subnetName'))]",

--- a/templates/apim/apim-service.json
+++ b/templates/apim/apim-service.json
@@ -111,7 +111,7 @@
     }
   },
   "variables": {
-    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/master/templates/",
+    "deploymentUrlBase": "https://raw.githubusercontent.com/SkillsFundingAgency/das-platform-building-blocks/DASD-9045-apim-dev-portal-tenant-id/templates/",
     "deployCustomHostnames": "[and(greater(length(parameters('portalKeyVaultCertificateName')), 0), greater(length(parameters('gatewayKeyVaultCertificateName')), 0))]",
     "deployToNetwork": "[and(greater(length(parameters('virtualNetworkName')), 0), not(equals(parameters('virtualNetworkType'), 'None')))]",
     "subnetResourceId": "[concat(resourceId(parameters('virtualNetworkResourceGroup'), 'Microsoft.Network/virtualNetworks', parameters('virtualNetworkName')), '/subnets/', parameters('subnetName'))]",

--- a/templates/apim/apim-service.json
+++ b/templates/apim/apim-service.json
@@ -100,7 +100,7 @@
       "type": "string",
       "defaultValue": ""
     },
-    "tenantPrimaryDomain": {
+    "tenantId": {
       "type": "string"
     },
     "apimAppRegistrationClientId": {
@@ -191,8 +191,8 @@
           "subnetResourceId": {
             "value": "[variables('subnetResourceId')]"
           },
-          "tenantPrimaryDomain": {
-            "value": "[parameters('tenantPrimaryDomain')]"
+          "tenantId": {
+            "value": "[parameters('tenantId')]"
           },
           "apimAppRegistrationClientId": {
             "value": "[parameters('apimAppRegistrationClientId')]"


### PR DESCRIPTION
PR in sync with https://github.com/SkillsFundingAgency/das-shared-infrastructure/pull/67

Recent breaking Azure change - when clicking AAD button to log into the APIM developer portal a call is now sent to  `https://login.windows.net/<signInTenant>/.well-known/openid-configuration` which fails if signInTenant isn't set.

This change appears to be correlated with the APIM Groups needing an externalId that uses the tenant ID instead of the tenant primary domain.