### PR TITLE
storage-account-arm: Set allowBlobPublicAccess to false

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -153,6 +153,7 @@
           "keySource": "Microsoft.Storage"
         },
         "accessTier": "[if(empty(parameters('accessTier')), json('null'), parameters('accessTier'))]",
+        "allowBlobPublicAccess": false,
         "supportsHttpsTrafficOnly": true,
         "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
       },


### PR DESCRIPTION
Set allowBlobPublicAccess property to false

All das storage accounts' containers are Private access

https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/2019-04-01/storageaccounts?tabs=bicep#storageaccountpropertiescreateparameters