### PR TITLE
storage-account-arm: Added allowSharedKeyAccess parameter

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -46,6 +46,10 @@
         "BlobStorage"
       ]
     },
+    "allowSharedKeyAccess": {
+      "type": "bool",
+      "defaultValue": true
+    },
     "subnetResourceIdList": {
       "type": "array",
       "defaultValue": [],
@@ -154,6 +158,7 @@
         },
         "accessTier": "[if(empty(parameters('accessTier')), json('null'), parameters('accessTier'))]",
         "allowBlobPublicAccess": false,
+        "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
         "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
       },


### PR DESCRIPTION
Added allowSharedKeyAccess parameter defaulting to true

https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/2019-04-01/storageaccounts?tabs=json#storageaccountpropertiescreateparameters

> Indicates whether the storage account permits requests to be authorized with the account access key via Shared Key. If false, then all requests, including shared access signatures, must be authorized with Azure Active Directory (Azure AD). The default value is null, which is equivalent to true.

Will change default to false once ARM templates consuming the building block pass the allowSharedKeyAccess parameter