### PR TITLE
templates/storage-account-arm: Added allowBlobPublicAccess parameter

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -46,6 +46,10 @@
         "BlobStorage"
       ]
     },
+    "allowBlobPublicAccess": {
+      "type": "bool",
+      "defaultValue": false
+    },
     "allowSharedKeyAccess": {
       "type": "bool",
       "defaultValue": true
@@ -157,7 +161,7 @@
           "keySource": "Microsoft.Storage"
         },
         "accessTier": "[if(empty(parameters('accessTier')), json('null'), parameters('accessTier'))]",
-        "allowBlobPublicAccess": false,
+        "allowBlobPublicAccess": "[parameters('allowBlobPublicAccess')]",
         "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
         "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -48,7 +48,10 @@
     },
     "allowBlobPublicAccess": {
       "type": "bool",
-      "defaultValue": false
+      "defaultValue": false,
+      "metadata": {
+        "description": "Allow or disallow public access to all blobs or containers in the storage account. Individual containers' access levels must also be set to Blob/Container to be accessible anonymously."
+      }
     },
     "allowSharedKeyAccess": {
       "type": "bool",


### PR DESCRIPTION
https://docs.microsoft.com/en-us/azure/templates/microsoft.storage/2019-04-01/storageaccounts?tabs=bicep#storageaccountpropertiescreateparameters

allowBlobPublicAccess
> Allow or disallow public access to all blobs or containers in the storage account. The default interpretation is true for this property.