### PR TITLE
Removed MongoRequests category from cosmos db diagnostic settings

### DIFF
--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -128,14 +128,6 @@
                 }
               },
               {
-                "category": "MongoRequests",
-                "enabled": true,
-                "retentionPolicy": {
-                  "enabled": true,
-                  "days": 90
-                }
-              },
-              {
                 "category": "ControlPlaneRequests",
                 "enabled": true,
                 "retentionPolicy": {


### PR DESCRIPTION
As per MSFT documentation for the MongoRequests log category on https://docs.microsoft.com/en-us/azure/cosmos-db/cosmosdb-monitor-resource-logs#choose-log-categories :

> When you enable this category, make sure to disable DataPlaneRequests.

The Azure Cosmos DB accounts can have both the DataPlaneRequests and ControlPlaneRequests categories enabled regardless of Cosmos API type