### PR TITLE
Updated the git versioning task to not use preview versions

### DIFF
--- a/azure-pipelines-templates/build/step/gitversion.yml
+++ b/azure-pipelines-templates/build/step/gitversion.yml
@@ -9,3 +9,4 @@ steps:
   inputs:
     useConfigFile: true
     configFilePath: GitVersion.yml
+    includePrerelease: false


### PR DESCRIPTION
Updated the gitversion yaml file to not allow the use of preview versions. We recently saw a few instances of builds failing because the GitVersion task was reporting trying to retrieve the latest preview version and failed because it was unable to download the package.