### PR TITLE
templates/service-bus.json: Added RuntimeAuditLogs category

### DIFF
--- a/templates/service-bus.json
+++ b/templates/service-bus.json
@@ -110,6 +110,14 @@
                   "enabled": true,
                   "days": 90
                 }
+              },
+              {
+                "category": "RuntimeAuditLogs",
+                "enabled": true,
+                "retentionPolicy": {
+                  "enabled": true,
+                  "days": 90
+                }
               }
             ]
           }


### PR DESCRIPTION
References:
https://docs.microsoft.com/en-us/azure/azure-monitor/essentials/resource-logs-categories#microsoftservicebusnamespaces
https://docs.microsoft.com/en-us/azure/service-bus-messaging/monitor-service-bus-reference#runtime-audit-logs

Runtime audit logs include the `AuthKey` element - `Azure Active Directory application ID or SAS policy name that's used to authenticate to a resource.`