### PR TITLE
App Insights Conn String, Workspace allow resource auth

### DIFF
--- a/templates/application-insights.json
+++ b/templates/application-insights.json
@@ -11,11 +11,25 @@
     "attachedService": {
       "defaultValue": "",
       "type": "string"
+    },
+    "logAnalyticsWorkspaceId": {
+      "defaultValue": "",
+      "type": "string"
     }
+  },
+  "variables" : {
+    "baseProperties": {
+      "Application_Type": "web"
+    },
+    "logAnalyticsWorkspaceProperties": {
+      "WorkspaceResourceId": "[parameters('logAnalyticsWorkspaceId')]"
+    },
+    "useWorkspace": "[greater(length(parameters('logAnalyticsWorkspaceId')),0)]",
+    "appInsightsProperties": "[if(variables('useWorkspace'),union(variables('baseProperties'),variables('logAnalyticsWorkspaceProperties')),variables('baseProperties'))]"
   },
   "resources": [
     {
-      "apiVersion": "2015-05-01",
+      "apiVersion": "2020-02-02",
       "name": "[parameters('appInsightsName')]",
       "type": "Microsoft.Insights/components",
       "location": "[resourceGroup().location]",
@@ -23,9 +37,7 @@
       "tags": {
         "[concat('hidden-link:', resourceId('Microsoft.Web/sites', parameters('attachedService')))]": "Resource"
       },
-      "properties": {
-        "Application_Type": "web"
-      }
+      "properties": "[variables('appInsightsProperties')]"
     }
   ],
   "outputs": {
@@ -40,6 +52,10 @@
     "AppInsightsResourceId": {
       "type": "string",
       "value": "[resourceId('Microsoft.Insights/components', parameters('appInsightsName'))]"
+    },
+    "ConnectionString": {
+      "type": "string",
+      "value": "[reference(concat('microsoft.insights/components/', parameters('appInsightsName'))).ConnectionString]"
     }
   }
 }

--- a/templates/log-analytics-workspace.json
+++ b/templates/log-analytics-workspace.json
@@ -48,7 +48,10 @@
         },
         "retentionInDays": "[parameters('dataRetentionDays')]",
         "publicNetworkAccessForIngestion": "[parameters('publicNetworkAccessForIngestion')]",
-        "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]"
+        "publicNetworkAccessForQuery": "[parameters('publicNetworkAccessForQuery')]",
+        "features": {
+          "enableLogAccessUsingOnlyResourcePermissions": true
+        }
       }
     }
   ],


### PR DESCRIPTION
App Insights output Connection string
App Insights will take an optional logAnalyticsWorkspaceId parameter
Log Analytics workspace should allow resource auth by default