### PR TITLE
app-reg-new-temp-client-secret.yml: Added sleep of 1 minute after client secret creation

### DIFF
--- a/azure-pipelines-templates/deploy/step/app-reg-new-temp-client-secret.yml
+++ b/azure-pipelines-templates/deploy/step/app-reg-new-temp-client-secret.yml
@@ -15,4 +15,6 @@ steps:
       Write-Output "Setting variables AppRegistrationTemporaryClientSecretId and AppRegistrationTemporaryClientSecret"
       Write-Output "##vso[task.setvariable variable=AppRegistrationTemporaryClientSecretId;isreadonly=true]$($ClientSecret.KeyId)"
       Write-Output "##vso[task.setvariable variable=AppRegistrationTemporaryClientSecret;isreadonly=true;issecret=true]$($ClientSecret.SecretText)"
+      Write-Output "Wait 1 minute in order for newly created client secret to be used successfully."
+      Start-Sleep -Seconds 60
     azurePowerShellVersion: LatestVersion


### PR DESCRIPTION
Azure.Identity.AuthenticationFailedException errors are experienced if a newly created client secret is used straight away. A sleep of 1 minute prevents these errors by allowing time for backend AAD processes to complete.