### PR TITLE
Created two new building blocks to enable pipelines to be whitelisted on app services via YAML tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,9 @@ Two new building block templates added to allow pipelines to be whitelisted on a
 
 Addition of the following files -
 
-[appservice-whitelist-ip.yml]
+[appservice-whitelist-ip.yml](https://github.com/SkillsFundingAgency/das-platform-building-blocks/tree/master/azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml)
 
-[appservice-remove-ip.yml]
+[appservice-remove-ip.yml](https://github.com/SkillsFundingAgency/das-platform-building-blocks/tree/master/azure-pipelines-templates/deploy/step/appservice-remove-ip.yml)
 
 # 2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.0.1
+
+Two new building block templates added to allow pipelines to be whitelisted on a singular or multiple app services and then be removed again.
+
+Addition of the following files -
+
+[appservice-whitelist-ip.yml]
+
+[appservice-remove-ip.yml]
+
 # 2.0.0
 
 Breaking change to [generate-config.yml](azure-pipelines-templates/deploy/step/generate-config.yml).  Additional parameters have been added to this step template and changes have been made to the way secrets are handled.  When updating to version 2 or beyond you will need to add EnvironmentName, StorageAccountName & StorageResourceGroup inputs.  You will also need to map any secret variables that are used in config generation in the ConfigurationSecrets variable.  Typically your call to the step template should look something like:
@@ -14,6 +24,6 @@ Breaking change to [generate-config.yml](azure-pipelines-templates/deploy/step/g
       BarSecretKey: $(BarSecretKey)
 ```
 
-# 1.0.7
+# 1.0.8
 
 Start of changelog

--- a/azure-pipelines-templates/deploy/step/appservice-remove-ip.yml
+++ b/azure-pipelines-templates/deploy/step/appservice-remove-ip.yml
@@ -1,0 +1,17 @@
+parameters:
+  ServiceConnection:
+  ResourceName:
+  AlwaysRun: true
+
+steps:
+- task: AzurePowerShell@5
+  displayName: 'Remove IP address from App Service'
+  ${{ if eq(parameters.AlwaysRun, true) }}:
+    condition: always()
+  ${{ if ne(parameters.AlwaysRun, true) }}:
+    condition: succeeded()
+  inputs:
+    azureSubscription: ${{ parameters.ServiceConnection }}
+    ScriptPath: '$(System.DefaultWorkingDirectory)/das-platform-automation/Infrastructure-Scripts/Remove-AppServiceIpException.ps1'
+    ScriptArguments: '-ResourceName ${{ parameters.ResourceName }} -IPAddress $(IPAddress)'
+    azurePowerShellVersion: LatestVersion

--- a/azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml
+++ b/azure-pipelines-templates/deploy/step/appservice-whitelist-ip.yml
@@ -1,0 +1,21 @@
+parameters:
+  ServiceConnection:
+  ResourceName:
+  RuleName:
+  ReturnIPSite: https://ifconfig.me/ip
+
+steps:
+- task: AzurePowerShell@5
+  displayName: 'Get Agent IP address'
+  inputs:
+    azureSubscription: ${{ parameters.ServiceConnection }}
+    ScriptPath: '$(System.DefaultWorkingDirectory)/das-platform-automation/Infrastructure-Scripts/Get-MyIpAddress.ps1'
+    ScriptArguments: '-WhatsMyIpUrl ${{ parameters.ReturnIPSite }}'
+    azurePowerShellVersion: LatestVersion
+- task: AzurePowerShell@5
+  displayName: 'Whitelist Agent IP address on App Service'
+  inputs:
+    azureSubscription: ${{ parameters.ServiceConnection }}
+    ScriptPath: '$(System.DefaultWorkingDirectory)/das-platform-automation/Infrastructure-Scripts/Add-AppServiceIpException.ps1'
+    ScriptArguments: '-ResourceName ${{ parameters.ResourceName }} -RuleName ${{ parameters.RuleName }} -IPAddress $(IPAddress)'
+    azurePowerShellVersion: LatestVersion


### PR DESCRIPTION
## Context

These changes are being made in order to allow app services including function apps to whitelist their agents onto a given app service. With new access restrictions now being applied to function apps in PP and PRD we require this in order for deployments to automated tests to succeed.

## Changes proposed in this pull request

Created two new building blocks to enable pipelines to be whitelisted on app services via YAML tasks

## Guidance to review
 
Check over YAML structure and that the proposed code follows existing standards.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
