### PR TITLE
Added Pull Request commenting if vulnerable packages are detected +semver: minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 2.1.0
+
+Addition to the app-build.yml azure-pipelines-template to comment on a Pull Request if the Package Scanning step detects any vulnerabilities.
+
+# 2.0.3
+
+Addition of two azure-pipelines-templates to allow app services including function apps to whitelist and remove the whilist of the pipeline agents.
+
+Needed for automation test suite pipelines.
+
 # 2.0.1
 
 Two new building block templates added to allow pipelines to be whitelisted on a singular or multiple app services and then be removed again.

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -52,12 +52,58 @@ steps:
     }
     if($ErrorFound){
       Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
+      Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
       $(exit 1)
     } else {
+        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
       $(exit 0)
     }
   displayName: Package Scanning
   continueOnError: true
+
+- task: DownloadSecureFile@1
+  name: DownloadDasGitHubAppPrivateKey
+  displayName: 'Download DAS GitHub App private key'
+  inputs:
+    secureFile: 'das-github-app-private-key.pem'
+
+- pwsh: |
+    $null = Register-PackageSource -Name NuGet -Location https://api.nuget.org/v3/index.json -ProviderName NuGet
+    #NOTE: Install-Package with -SkipDependencies flag used until PowerShellGet v3 can be used to only install Octokit and GitHubJwt along with their dependencies.
+    #NOTE: https://github.com/PowerShell/PowerShellGet/issues/487#issue-1000366159
+    $null = Install-Package -Name "Octokit" -RequiredVersion "4.0.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+    $null = Install-Package -Name "GitHubJwt" -RequiredVersion "0.0.5" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+    $null = Install-Package -Name "jose-jwt" -RequiredVersion "4.0.1" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+    $null = Install-Package -Name "BouncyCastle.NetCore" -RequiredVersion "1.9.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+
+    $OctokitDll = "$(Agent.TempDirectory)/packages/Octokit.4.0.0/lib/netstandard2.0/Octokit.dll"
+    $GitHubJwtDll = "$(Agent.TempDirectory)/packages/GitHubJwt.0.0.5/lib/netstandard2.0/GitHubJwt.dll"
+    $JoseJwtDll = "$(Agent.TempDirectory)/packages/jose-jwt.4.0.1/lib/netstandard2.1/jose-jwt.dll"
+    $BouncyCastleCryptoDll = "$(Agent.TempDirectory)/packages/BouncyCastle.NetCore.1.9.0/lib/netstandard2.0/BouncyCastle.Crypto.dll"
+
+    $null = Add-Type -Path $OctokitDll
+    $null = Add-Type -Path $GitHubJwtDll
+    $null = Add-Type -Path $JoseJwtDll
+    $null = Add-Type -Path $BouncyCastleCryptoDll
+
+    $PrivateKey = [GitHubJwt.FilePrivateKeySource]::new("$(DownloadDasGitHubAppPrivateKey.secureFilePath)")
+    $GitHubJwtFactoryOptions = [GitHubJwt.GitHubJwtFactoryOptions]::new()
+    $GitHubJwtFactoryOptions.AppIntegrationId = $(DasGitHubAppId)
+    $GitHubJwtFactoryOptions.ExpirationSeconds = 60
+    $Generator = [GitHubJwt.GitHubJwtFactory]::new($PrivateKey, $GitHubJwtFactoryOptions)
+    $JwtToken = $Generator.CreateEncodedJwtToken()
+
+    $AppClient = [Octokit.GitHubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app"))
+    $AppClient.Credentials = [Octokit.Credentials]::new($JwtToken, ([Octokit.AuthenticationType]::Bearer))
+    $Response = $AppClient.GitHubApps.CreateInstallationToken($(DasGitHubAppInstallationId)).Result
+
+    $PullRequestComment = "Please remember to check any packages used by this application to ensure they are up to date @$(Build.SourceVersionAuthor). cc/ $(PullRequestVulnerabilitiesDetectedTaggedUsers)"
+
+    $InstallationClient = [Octokit.GithubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app-installation"))
+    $InstallationClient.Credentials = [Octokit.Credentials]::new($Response.Token)
+    $InstallationClient.Issue.Comment.Create("$(Build.Repository.Name)".Split('/')[0], "$(Build.Repository.Name)".Split('/')[1], $(System.PullRequest.PullRequestNumber), $PullRequestComment)
+  displayName: Pull Request Commenting
+  condition: and(succeeded(), eq(variables.VulnerablePackagesDetected, 'true'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables.PullRequestVulnerabilitiesCommentTaskEnabled, 'true'))
 
 - task: DotNetCoreCLI@2
   displayName: Build


### PR DESCRIPTION
## Context

Notify pull request raisers to review vulnerable packages detected in the build's Package Scanning step

Guidance and recommended packages taken from https://github.com/octokit/octokit.net/blob/main/docs/github-apps.md

NOTE: Install-Package with -SkipDependencies flag used until PowerShellGet v3 can be used to only install Octokit and GitHubJwt along with their dependencies - https://github.com/PowerShell/PowerShellGet/issues/487#issue-1000366159

## Guidance to review

View pipeline runs on my own personal repositories or create own GitHub app

## Things to check

- [x] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [x] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
