### PR TITLE
templates/cosmos-db.json: Set backupPolicy to Continuous +semver: minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
-# 2.2.0
+# 2.1.0
+
+templates/cosmos-db.json: Set backupPolicy to Continuous mode (30 days) for Azure Cosmos DB accounts.
+
+# 2.0.5
 
 Migrated from azure-pipelines.yml to .github/workflows/release.yml to avoid PAT token usage.
-
-# 2.1.0
 
 Addition to the app-build.yml azure-pipelines-template to comment on a Pull Request if the Package Scanning step detects any vulnerabilities.
 

--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -61,6 +61,9 @@
       }
     },
     "baseCosmosProperties": {
+      "backupPolicy": {
+        "type": "Continuous"
+      },
       "consistencyPolicy": {
         "defaultConsistencyLevel": "[parameters('defaultConsistencyLevel')]"
       },


### PR DESCRIPTION
## Context

Azure Cosmos DB Accounts offer two backup modes: Periodic and Continuous (Point In Time Restore).
Benefits of Continuous backup mode are listed at https://learn.microsoft.com/en-us/azure/cosmos-db/migrate-continuous-backup

## Changes proposed in this pull request

Set backupPolicy of Azure Cosmos DB Accounts to Continuous (30 days) mode
Reference: https://learn.microsoft.com/en-us/azure/cosmos-db/continuous-backup-restore-introduction

## Things to check

- [x] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [x] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
