### PR TITLE
Added ASP autoscaling option to templates/app-service-plan.json

### DIFF
--- a/templates/app-service-plan.json
+++ b/templates/app-service-plan.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "appServicePlanName": {
@@ -31,6 +31,34 @@
     },
     "aspInstances": {
       "type": "int"
+    },
+    "applyAutoScale": {
+      "type": "bool",
+      "defaultValue": false
+    },
+    "autoScaleMinAspInstances": {
+      "type": "int",
+      "defaultValue": 2
+    },
+    "autoScaleMaxAspInstances": {
+      "type": "int",
+      "defaultValue": 3
+    },
+    "autoScaleMinCpuPercentageThreshold": {
+      "type": "int",
+      "defaultValue": 20
+    },
+    "autoScaleMaxCpuPercentageThreshold": {
+      "type": "int",
+      "defaultValue": 70
+    },
+    "autoScaleMinMemoryPercentageThreshold": {
+      "type": "int",
+      "defaultValue": 20
+    },
+    "autoScaleMaxMemoryPercentageThreshold": {
+      "type": "int",
+      "defaultValue": 70
     },
     "nonASETier": {
       "type": "string",
@@ -82,6 +110,118 @@
       "location": "[parameters('aspLocation')]",
       "properties": "[if(variables('DeployToASE'), variables('ASPResourceProperties').WithASE, variables('ASPResourceProperties').WithoutASE)]",
       "sku": "[if(variables('DeployToASE'), variables('defaultAppServicePlanSKUs').Isolated, variables('defaultAppServicePlanSKUs').NonASE)]"
+    },
+    {
+      "condition": "[parameters('applyAutoScale')]",
+      "type": "microsoft.insights/autoscalesettings",
+      "apiVersion": "2022-10-01",
+      "name": "[concat(parameters('appServicePlanName'), '-autoscalesettings')]",
+      "location": "[parameters('aspLocation')]",
+      "properties": {
+        "profiles": [
+          {
+            "name": "Scale condition",
+            "capacity": {
+              "minimum": "[string(parameters('autoScaleMinAspInstances'))]",
+              "maximum": "[string(parameters('autoScaleMaxAspInstances'))]",
+              "default": "[if(variables('DeployToASE'), string(variables('defaultAppServicePlanSKUs').Isolated.capacity), string(variables('defaultAppServicePlanSKUs').NonASE.capacity))]"
+            },
+            "rules": [
+              {
+                "metricTrigger": {
+                  "metricName": "CpuPercentage",
+                  "metricNamespace": "microsoft.web/serverfarms",
+                  "metricResourceUri": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT10M",
+                  "timeAggregation": "Average",
+                  "operator": "LessThan",
+                  "threshold": "[parameters('autoScaleMinCpuPercentageThreshold')]",
+                  "dimensions": [],
+                  "dividePerInstance": false
+                },
+                "scaleAction": {
+                  "direction": "Decrease",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT5M"
+                }
+              },
+              {
+                "metricTrigger": {
+                  "metricName": "CpuPercentage",
+                  "metricNamespace": "microsoft.web/serverfarms",
+                  "metricResourceUri": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT10M",
+                  "timeAggregation": "Average",
+                  "operator": "GreaterThan",
+                  "threshold": "[parameters('autoScaleMaxCpuPercentageThreshold')]",
+                  "dimensions": [],
+                  "dividePerInstance": false
+                },
+                "scaleAction": {
+                  "direction": "Increase",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT5M"
+                }
+              },
+              {
+                "metricTrigger": {
+                  "metricName": "MemoryPercentage",
+                  "metricNamespace": "microsoft.web/serverfarms",
+                  "metricResourceUri": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT10M",
+                  "timeAggregation": "Average",
+                  "operator": "LessThan",
+                  "threshold": "[parameters('autoScaleMinMemoryPercentageThreshold')]",
+                  "dimensions": [],
+                  "dividePerInstance": false
+                },
+                "scaleAction": {
+                  "direction": "Decrease",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT5M"
+                }
+              },
+              {
+                "metricTrigger": {
+                  "metricName": "MemoryPercentage",
+                  "metricNamespace": "microsoft.web/serverfarms",
+                  "metricResourceUri": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+                  "timeGrain": "PT1M",
+                  "statistic": "Average",
+                  "timeWindow": "PT10M",
+                  "timeAggregation": "Average",
+                  "operator": "GreaterThan",
+                  "threshold": "[parameters('autoScaleMaxMemoryPercentageThreshold')]",
+                  "dimensions": [],
+                  "dividePerInstance": false
+                },
+                "scaleAction": {
+                  "direction": "Increase",
+                  "type": "ChangeCount",
+                  "value": "1",
+                  "cooldown": "PT5M"
+                }
+              }
+            ]
+          }
+        ],
+        "enabled": true,
+        "name": "[concat(parameters('appServicePlanName'), '-autoscalesettings')]",
+        "targetResourceUri": "[resourceId('Microsoft.Web/serverfarms', parameters('appServicePlanName'))]",
+        "notifications": [],
+        "predictiveAutoscalePolicy": {
+          "scaleMode": "Disabled"
+        }
+      }
     }
   ],
   "outputs": {


### PR DESCRIPTION
## Context

Allow flexible autoscaling of ASPs based on ASP metrics

## Changes proposed in this pull request

Addition of an `microsoft.insights/autoscalesettings` resource with parameter applyAutoScale defaulting to false

## Guidance to review

Confirm successful deployment using the updated building block
Assess what the defaults of count and thresholds should be

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
