### PR TITLE
Added error handling & parameterized continueOnError

### DIFF
--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnErrors: false
+  ContinueOnVulnerablePackageScanError: false
 
 steps:
 - task: SonarCloudPrepare@1
@@ -52,22 +52,16 @@ steps:
       }
     }
 
-    try {
-        if($ErrorFound){
-            Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
-            Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
-            $(exit 1)
-        } 
-        else {
-            Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
-            $(exit 0)
-        }
-    }
-    catch {
-        Write-Error $_.Exception.Message
-    }
+    if($ErrorFound){
+        Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
+        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
+        $(exit 1)
+    } 
+    else {
+        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
+        $(exit 0)
   displayName: Package Scanning
-  continueOnError: ${{ parameters.ContinueOnErrors }}
+  continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -60,6 +60,7 @@ steps:
     else {
         Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
         $(exit 0)
+    }
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
 

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnVulnerablePackageScanError: true
+  ContinueOnVulnerablePackageScanError: false
 
 steps:
 - task: SonarCloudPrepare@1

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnVulnerablePackageScanError: false
+  ContinueOnVulnerablePackageScanError: true
 
 steps:
 - task: SonarCloudPrepare@1

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnErrors: true
+  ContinueOnErrors: false
 
 steps:
 - task: SonarCloudPrepare@1
@@ -51,7 +51,7 @@ steps:
         }
       }
     }
-    
+
     try {
         if($ErrorFound){
             Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,6 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
+  ContinueOnErrors: true
 
 steps:
 - task: SonarCloudPrepare@1
@@ -50,16 +51,23 @@ steps:
         }
       }
     }
-    if($ErrorFound){
-      Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
-      Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
-      $(exit 1)
-    } else {
-        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
-      $(exit 0)
+    
+    try {
+        if($ErrorFound){
+            Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
+            Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
+            $(exit 1)
+        } 
+        else {
+            Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
+            $(exit 0)
+        }
+    }
+    catch {
+        Write-Error $_.Exception.Message
     }
   displayName: Package Scanning
-  continueOnError: true
+  continueOnError: ${{ parameters.ContinueOnErrors }}
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey


### PR DESCRIPTION
## Context

<!-- Why are you making this change? What might surprise someone about it? -->

## Changes proposed in this pull request

Change to make a pipeline fail by default and not Continue on Error if the Package Scanning step finds any vulnerabilities. Added an optional boolean parameter to app-build.yml that allows the Package Scanning step to continue on error as per existing behaviour.

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
