### PR TITLE
DASD-9900 - Added parameter to allow key vault to use RBAC for data actions inste…

### DIFF
--- a/templates/keyvault.json
+++ b/templates/keyvault.json
@@ -12,6 +12,10 @@
         "description": "Array of objects with the following schema: https://docs.microsoft.com/en-us/azure/templates/microsoft.keyvault/2018-02-14/vaults#AccessPolicyEntry"
       }
     },
+    "enableRbacAuthorization": {
+      "type": "bool",
+      "defaultValue": false
+    },
     "enabledForDiskEncryption": {
       "type": "bool",
       "defaultValue": false
@@ -102,6 +106,7 @@
       "apiVersion": "2018-02-14",
       "location": "[resourceGroup().location]",
       "properties": {
+        "enableRbacAuthorization": "[parameters('enableRbacAuthorization')]",
         "enabledForDiskEncryption": "[parameters('enabledForDiskEncryption')]",
         "enabledForTemplateDeployment": "[parameters('enabledForTemplateDeployment')]",
         "enableSoftDelete": true,


### PR DESCRIPTION
…ad of Access policies

## Context

Added `enableRbacAuthorization` parameter to allow key vaults to use RBAC for authorisation of data actions instead of Access policies when the parameter is set to true. It will default to false if not set in the ARM template and will allow the use of access policies.
https://learn.microsoft.com/en-us/azure/templates/microsoft.keyvault/vaults?pivots=deployment-language-arm-template#:~:text=bool-,enableRbacAuthorization,-Property%20that%20controls

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
