### PR TITLE
Set service bus role assignment GUID to be dependent on 3 properties to allow uniqueness

### DIFF
--- a/templates/role-assignments/role-assignment-service-bus.json
+++ b/templates/role-assignments/role-assignment-service-bus.json
@@ -26,7 +26,7 @@
     {
       "type": "Microsoft.ServiceBus/namespaces/providers/roleAssignments",
       "apiVersion": "2018-09-01-preview",
-      "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('principalId'))))]",
+      "name": "[concat(parameters('resourceName'), '/Microsoft.Authorization/', guid(uniqueString(parameters('principalId'), parameters('resourceName'), last(split(variables(parameters('assignmentType')), '/')))))]",
       "properties": {
         "roleDefinitionId": "[variables(parameters('assignmentType'))]",
         "principalId": "[parameters('principalId')]"


### PR DESCRIPTION
## Context

As per https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments#name:
'Role assignment resource names must be unique within the Azure Active Directory tenant, even if the scope of the role assignment is narrower.'

## Changes proposed in this pull request

Set role assignment name GUID to be dependent on 3 properties to ensure uniqueness within the tenant:

- `principalId` of resource's MI which will be granted permission
- `resourceName` of resource being granted permission over
- The ID of the role assignment

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
