### PR TITLE
Add location to Azure Search

### DIFF
--- a/templates/azure-search.json
+++ b/templates/azure-search.json
@@ -47,6 +47,14 @@
       "metadata": {
         "description": "Partitions allow for scaling of document count as well as faster indexing by sharding your index over multiple Azure Search units."
       }
+    },
+    "azureSearchLocation": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "allowedValues": [
+        "northeurope",
+        "westeurope"
+      ]
     }
   },
   "resources": [
@@ -54,7 +62,7 @@
       "apiVersion": "2015-08-19",
       "name": "[parameters('azureSearchName')]",
       "type": "Microsoft.Search/searchServices",
-      "location": "[resourceGroup().location]",
+      "location": "[parameters('azureSearchLocation')]",
       "sku": {
         "name": "[toLower(parameters('azureSearchSku'))]"
       },


### PR DESCRIPTION
## Context

Deployment of Azure AI Search is currently disabled in West Europe. The current template supports deploying the resource to `resourceGroup().location` which will always be West Europe.

## Changes proposed in this pull request

Add the ability to set the location of the resource deployment.

## Guidance to review

Confirmed the template is valid using Azure CLI --what-if