### PR TITLE
Add free tier to ASP template

### DIFF
--- a/templates/app-service-plan.json
+++ b/templates/app-service-plan.json
@@ -35,6 +35,7 @@
     "nonASETier": {
       "type": "string",
       "allowedValues": [
+        "Free",
         "Basic",
         "Standard",
         "Premium",


### PR DESCRIPTION
## Context

Some of the shared ASP's are set to the free tier but our shared infrastructure deployment does not support this.

## Changes proposed in this pull request

Add free tier for ASP's already using it.

## Guidance to review

Tested deployment in to DTA
