### PR TITLE
Set AI search API access control to RBAC

### DIFF
--- a/templates/azure-search.json
+++ b/templates/azure-search.json
@@ -69,6 +69,10 @@
         "northeurope",
         "westeurope"
       ]
+    },
+    "aiSearchDisableLocalAuth": {
+      "type" : "bool",
+      "defaultValue": true
     }
   },
   "resources": [
@@ -87,7 +91,8 @@
         "replicaCount": "[parameters('aiSearchReplicaCount')]",
         "partitionCount": "[parameters('aiSearchPartitionCount')]",
         "hostingMode": "[parameters('aiSearchHostingMode')]",
-        "publicNetworkAccess": "[parameters('aiSearchPublicNetworkAccess')]"
+        "publicNetworkAccess": "[parameters('aiSearchPublicNetworkAccess')]",
+        "disableLocalAuth": "[parameters('aiSearchDisableLocalAuth')]"
       }
     }
   ],


### PR DESCRIPTION
## Context

Set AI search API access control to RBAC to prevent the use of API keys to access the service

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
