### PR TITLE
DASD-10547 - Prepare redis template for private endpoint

### DIFF
--- a/templates/redis.json
+++ b/templates/redis.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "redisCacheName": {
@@ -24,17 +24,26 @@
     "minimumTlsVersion": {
       "type": "string",
       "defaultValue": "1.2"
+    },
+    "publicNetworkAccess": {
+      "type": "string",
+      "allowedValues": [
+        "Enabled",
+        "Disabled"
+      ],
+      "defaultValue": "Enabled"
     }
   },
   "resources": [
     {
-      "apiVersion": "2018-03-01",
+      "apiVersion": "2023-08-01",
       "name": "[parameters('redisCacheName')]",
       "type": "Microsoft.Cache/Redis",
       "location": "[resourceGroup().location]",
       "properties": {
         "enableNonSslPort": "[parameters('enableNonSslPort')]",
         "minimumTlsVersion": "[parameters('minimumTlsVersion')]",
+        "publicNetworkAccess": "[parameters('publicNetworkAccess')]",
         "sku": {
           "capacity": "[parameters('redisCacheCapacity')]",
           "family": "[parameters('redisCacheFamily')]",
@@ -46,19 +55,19 @@
   "outputs": {
     "PrimaryKey": {
       "type": "securestring",
-      "value": "[listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2018-03-01').primaryKey]"
+      "value": "[listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2023-08-01').primaryKey]"
     },
     "SecondaryKey": {
       "type": "securestring",
-      "value": "[listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2018-03-01').secondaryKey]"
+      "value": "[listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2023-08-01').secondaryKey]"
     },
     "PrimaryConnectionString": {
       "type": "securestring",
-      "value": "[concat(parameters('redisCacheName'), '.redis.cache.windows.net:6380,password=', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2018-03-01').primaryKey, ',ssl=True,abortConnect=False')]"
+      "value": "[concat(parameters('redisCacheName'), '.redis.cache.windows.net:6380,password=', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2023-08-01').primaryKey, ',ssl=True,abortConnect=False')]"
     },
     "SecondaryConnectionString": {
       "type": "securestring",
-      "value": "[concat(parameters('redisCacheName'), '.redis.cache.windows.net:6380,password=', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2018-03-01').secondaryKey, ',ssl=True,abortConnect=False')]"
+      "value": "[concat(parameters('redisCacheName'), '.redis.cache.windows.net:6380,password=', listKeys(resourceId('Microsoft.Cache/Redis', parameters('redisCacheName')),'2023-08-01').secondaryKey, ',ssl=True,abortConnect=False')]"
     }
   }
 }


### PR DESCRIPTION
## Context

When a private endpoint is added to an Azure Cache for Redis instance, it toggles the publicNetworkAccess property. In order to toggle this back to its original value we need to explicitly define the value in the template.

## Changes proposed in this pull request

- Add publicNetworkAccess parameter for redis
- Update apiVersion to support publicNetworkAccess
- Update template schema

## Guidance to review

Check the das-shared-infrastructure deployment for the branch/PR in ADO.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
