### PR TITLE
Added Manual App role assignments

### DIFF
--- a/azure-pipelines-templates/deploy/step/app-role-assignments.yml
+++ b/azure-pipelines-templates/deploy/step/app-role-assignments.yml
@@ -5,6 +5,7 @@ parameters:
   AADGroupObjectIdArray:
   IsMultiRepoCheckout: false
   DryRun: $false
+  TargetEnvironment: '""'
 
 steps:
 - checkout: das-platform-automation
@@ -23,12 +24,13 @@ steps:
         -AppRegistrationConfigurationFilePath $(Pipeline.Workspace)/das-employer-config/Configuration/app-role-assignments/config.json
         -ResourceName ${{ parameters.ResourceName }}
         -Tenant ${{ parameters.Tenant }}
+        -TargetEnvironment ${{ parameters.TargetEnvironment }}
         -DryRun ${{ parameters.DryRun }}
     ${{ else }}:
       arguments:
         -AppRegistrationConfigurationFilePath $(Pipeline.Workspace)/das-employer-config/Configuration/app-role-assignments/config.json
         -ResourceName ${{ parameters.ResourceName }}
         -Tenant ${{ parameters.Tenant }}
+        -TargetEnvironment ${{ parameters.TargetEnvironment }}
         -DryRun ${{ parameters.DryRun }}
         -AADGroupObjectIdArray ${{parameters.AADGroupObjectIdArray }}
-        


### PR DESCRIPTION
This is to address Nas Migrated APIM instances RE: DASD-10990

## Context

To address app role assignments for nas migrated APIM instances

## Changes proposed in this pull request

New manual-app-role-assignments YAML which will pass an extra TargetEnvironment param to the Set-AppRoleAssignments script.

## Guidance to review

[das-apim run](https://sfa-gov-uk.visualstudio.com/Apprenticeships%20Service%20Cloud%20Platform/_build/results?buildId=782485&view=logs&s=3b7ea4b9-3dd9-5196-e725-9226a8d63073) - See PreProd run here to see successful usage
