### PR TITLE
Dasd 11062 sonar cloud update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.21
+
+Updated SonarCloud config to use the latest version currently 2.x
+
 # 2.1.1
 
 Removed unused azure-pipelines-templates/deploy/job/arm-deploy.yml and moved placeholder file.

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -10,7 +10,7 @@ parameters:
   ContinueOnVulnerablePackageScanError: false
 
 steps:
-- task: SonarCloudPrepare@1
+- task: SonarCloudPrepare@5
   displayName: Prepare SonarCloud analysis configuration
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
@@ -131,11 +131,11 @@ steps:
     publishTestResults: true
     arguments: '--configuration $(buildConfiguration) --no-build  /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/CoverageResults/ /p:MergeWith=$(Agent.TempDirectory)/CoverageResults/coverage.json /p:CoverletOutputFormat="opencover%2cjson"'
 
-- task: SonarCloudAnalyze@1
+- task: SonarCloudAnalyze@5
   displayName: Run SonarCloud analysis
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
-- task: SonarCloudPublish@1
+- task: SonarCloudPublish@5
   displayName: Publish SonarCloud analysis results on build summary
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -10,7 +10,7 @@ parameters:
   ContinueOnVulnerablePackageScanError: false
 
 steps:
-- task: SonarCloudPrepare@5
+- task: SonarCloudPrepare@2
   displayName: Prepare SonarCloud analysis configuration
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
@@ -131,11 +131,11 @@ steps:
     publishTestResults: true
     arguments: '--configuration $(buildConfiguration) --no-build  /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/CoverageResults/ /p:MergeWith=$(Agent.TempDirectory)/CoverageResults/coverage.json /p:CoverletOutputFormat="opencover%2cjson"'
 
-- task: SonarCloudAnalyze@5
+- task: SonarCloudAnalyze@2
   displayName: Run SonarCloud analysis
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
-- task: SonarCloudPublish@5
+- task: SonarCloudPublish@2
   displayName: Publish SonarCloud analysis results on build summary
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -12,7 +12,7 @@ parameters:
 steps:
 - task: SonarCloudPrepare@2
   displayName: Prepare SonarCloud analysis configuration
-#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     SonarCloud: ESFA - SonarCloud
     organization: $(SonarCloudOrganisationKey)
@@ -133,10 +133,10 @@ steps:
 
 - task: SonarCloudAnalyze@2
   displayName: Run SonarCloud analysis
-#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
 - task: SonarCloudPublish@2
   displayName: Publish SonarCloud analysis results on build summary
-#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     pollingTimeoutSec: '300'

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -10,7 +10,7 @@ parameters:
   ContinueOnVulnerablePackageScanError: false
 
 steps:
-- task: SonarCloudPrepare@2.1.0
+- task: SonarCloudPrepare@2
   displayName: Prepare SonarCloud analysis configuration
 #  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
@@ -131,11 +131,11 @@ steps:
     publishTestResults: true
     arguments: '--configuration $(buildConfiguration) --no-build  /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/CoverageResults/ /p:MergeWith=$(Agent.TempDirectory)/CoverageResults/coverage.json /p:CoverletOutputFormat="opencover%2cjson"'
 
-- task: SonarCloudAnalyze@2.1.0
+- task: SonarCloudAnalyze@2
   displayName: Run SonarCloud analysis
 #  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
-- task: SonarCloudPublish@2.1.0
+- task: SonarCloudPublish@2
   displayName: Publish SonarCloud analysis results on build summary
 #  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -12,7 +12,7 @@ parameters:
 steps:
 - task: SonarCloudPrepare@2.1.0
   displayName: Prepare SonarCloud analysis configuration
-  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     SonarCloud: ESFA - SonarCloud
     organization: $(SonarCloudOrganisationKey)
@@ -133,10 +133,10 @@ steps:
 
 - task: SonarCloudAnalyze@2.1.0
   displayName: Run SonarCloud analysis
-  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
 - task: SonarCloudPublish@2.1.0
   displayName: Publish SonarCloud analysis results on build summary
-  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
+#  condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     pollingTimeoutSec: '300'

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -10,7 +10,7 @@ parameters:
   ContinueOnVulnerablePackageScanError: false
 
 steps:
-- task: SonarCloudPrepare@2
+- task: SonarCloudPrepare@2.1.0
   displayName: Prepare SonarCloud analysis configuration
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
@@ -131,11 +131,11 @@ steps:
     publishTestResults: true
     arguments: '--configuration $(buildConfiguration) --no-build  /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/CoverageResults/ /p:MergeWith=$(Agent.TempDirectory)/CoverageResults/coverage.json /p:CoverletOutputFormat="opencover%2cjson"'
 
-- task: SonarCloudAnalyze@2
+- task: SonarCloudAnalyze@2.1.0
   displayName: Run SonarCloud analysis
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
-- task: SonarCloudPublish@2
+- task: SonarCloudPublish@2.1.0
   displayName: Publish SonarCloud analysis results on build summary
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:


### PR DESCRIPTION
## Context

This is to update the platform building blocks config to use the latest version of sonar cloud as the current version being 1.45.1 has deprecated packages.

## Changes proposed in this pull request

Changed the solarcloud config to use the latest version 2.X

## Guidance to review

I have tested this using custom branches please see the below to see the successful run with the latest sonarcloud version.

Before - https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/results?buildId=784190&view=results
After - https://sfa-gov-uk.visualstudio.com/Digital%20Apprenticeship%20Service/_build/results?buildId=789734&view=results

## Things to check

- [x] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
