### PR TITLE
DASD-10554 - Migrate Storage Accounts to Minimum TLS version of 1.2

### DIFF
--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnVulnerablePackageScanError: true
+  ContinueOnVulnerablePackageScanError: false
 
 steps:
 - task: SonarCloudPrepare@2

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -7,7 +7,7 @@ parameters:
   TargetProjects: 'src/**/*.csproj'
   UnitTestProjects: '**/*UnitTests.csproj'
   AcceptanceTestProjects: '**/*.AcceptanceTests.csproj'
-  ContinueOnVulnerablePackageScanError: false
+  ContinueOnVulnerablePackageScanError: true
 
 steps:
 - task: SonarCloudPrepare@2

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -82,10 +82,16 @@
     },
     "minimumTlsVersion": {
       "type": "string",
-      "defaultValue": "TLS1_2",
       "metadata": {
-       "description": "Set the minimum TLS version to be permitted on requests to storage."
-      }
+       "displayName": "Minimum TLS Version",
+       "description": "Minimum version of TLS required to access data in storage accounts"
+      },
+      "allowedValues": [
+          "TLS1_0",
+          "TLS1_1",
+          "TLS1_2"
+        ],
+      "defaultValue": "TLS1_0"
     },
     "allowedHeaders": {
       "type": "array",

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -82,10 +82,10 @@
     },
     "minimumTlsVersion": {
       "type": "string",
+      "defaultValue": "TLS1_2",
       "metadata": {
        "description": "Set the minimum TLS version to be permitted on requests to storage."
-      },
-      "defaultValue": "TLS1_2"
+      }
     },
     "allowedHeaders": {
       "type": "array",

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -82,7 +82,7 @@
     },
     "minimumTlsVersion": {
       "type": "string",
-      "defaultValue": "TLS1_2"
+      "defaultValue": "1.2"
     },
     "allowedHeaders": {
       "type": "array",
@@ -180,7 +180,8 @@
         "allowBlobPublicAccess": "[parameters('allowBlobPublicAccess')]",
         "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
-        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]",
+        "minimumTlsVersion": "[parameters('minimumTlsVersion')]"
       },
       "resources": [
         {

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -88,7 +88,6 @@
       },
       "allowedValues": [
           "TLS1_0",
-          "TLS1_1",
           "TLS1_2"
         ],
       "defaultValue": "TLS1_0"

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -80,6 +80,10 @@
         "True"
       ]
     },
+    "minimumTlsVersion": {
+      "type": "string",
+      "defaultValue": "TLS1_2"
+    },
     "allowedHeaders": {
       "type": "array",
       "defaultValue": [

--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -82,7 +82,10 @@
     },
     "minimumTlsVersion": {
       "type": "string",
-      "defaultValue": "1.2"
+      "metadata": {
+       "description": "Set the minimum TLS version to be permitted on requests to storage."
+      },
+      "defaultValue": "TLS1_2"
     },
     "allowedHeaders": {
       "type": "array",


### PR DESCRIPTION
## Context

Some storage accounts still use a minimum TLS version of 1.0. While the apps may use 1.2, we need to enforce this on the storage account configuration as support for TLS 1.0 and 1.1 retires starting Nov 1st 2024.

## Changes proposed in this pull request

Add the minimum TLS version for Azure Storage accounts to be 1.2 with following arm code

 "minimumTlsVersion": {
      "type": "string",
      "defaultValue": "TLS1_2"
    },

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
