### PR TITLE
DASD-11129 - Add ASP tier option

### DIFF
--- a/templates/app-service-plan.json
+++ b/templates/app-service-plan.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "appServicePlanName": {

--- a/templates/app-service-plan.json
+++ b/templates/app-service-plan.json
@@ -39,7 +39,8 @@
         "Basic",
         "Standard",
         "Premium",
-        "PremiumV2"
+        "PremiumV2",
+        "PremiumV3"
       ],
       "defaultValue": "Standard"
     }
@@ -57,7 +58,7 @@
         "name": "[parameters('appServicePlanName')]"
       }
     },
-    "aspSkuName": "[concat(take(parameters('nonASETier'), 1), parameters('aspSize'), if(equals(parameters('nonASETier'), 'PremiumV2'), 'v2', ''))]",
+    "aspSkuName": "[concat(take(parameters('nonASETier'), 1), parameters('aspSize'), if(equals(parameters('nonASETier'), 'PremiumV2'), 'v2', ''), if(equals(parameters('nonASETier'), 'PremiumV3'), 'v3', ''))]",
     "defaultAppServicePlanSKUs": {
       "NonASE": {
         "name": "[variables('aspSkuName')]",


### PR DESCRIPTION
## Context

We want to be able to deploy Pv3 ASP's using the ASP template

## Changes proposed in this pull request

Add option to deploy Pv3 ASP tier to ASP template
Update schema template version

## Guidance to review

- [x] Tested in own environment

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
