### PR TITLE
DASD-10554 - Migrate Storage Accounts to Minimum TLS version of 1.2

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -80,6 +80,18 @@
         "True"
       ]
     },
+    "minimumTlsVersion": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Minimum TLS Version",
+        "description": "Minimum version of TLS required to access data in storage accounts"
+      },
+      "allowedValues": [
+        "TLS1_0",
+        "TLS1_2"
+      ],
+      "defaultValue": "TLS1_0"
+    },
     "allowedHeaders": {
       "type": "array",
       "defaultValue": [
@@ -176,7 +188,8 @@
         "allowBlobPublicAccess": "[parameters('allowBlobPublicAccess')]",
         "allowSharedKeyAccess": "[parameters('allowSharedKeyAccess')]",
         "supportsHttpsTrafficOnly": true,
-        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]"
+        "networkAcls": "[if(or(greater(length(parameters('subnetResourceIdList')), 0),greater(length(parameters('allowedIpAddressesList')), 0)), variables('networkAclObject'), json('null'))]",
+        "minimumTlsVersion": "[parameters('minimumTlsVersion')]"
       },
       "resources": [
         {


### PR DESCRIPTION
## Context

As requested as part of the following ticket.

https://skillsfundingagency.atlassian.net/jira/software/c/projects/DASD/boards/391?selectedIssue=DASD-10554

Microsoft are retiring TLS version 1.0 and 1.1 for storage accounts before the end of the year.

## Changes proposed in this pull request

Add the minimumTlsVersion parameter to allow greater control of setting the TLS version of storage accounts within the das-infrastructure

## Guidance to review

This can be tested on existing repo, with a deployed version of this file and see the changes on the Azure portal to check id the minimum TLS version has been changed.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
