### PR TITLE
Adding healthcheckpath to platform-building-blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.26
+
+Adding the health check property to app-service-v2.json
+
 # 2.1.22
 
 Addition to the role-assignments.json, created a template for Log Analytics role assignment

--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -84,6 +84,13 @@
         "description": "Use if any settings will be different between production and staging slots. Specify in the name of the setting in the SlotSetting parameters"
       }
     },
+    "healthCheckPath": {
+      "type": "string",
+      "defaultValue": "",
+      "metadata": {
+        "description": "The path for the health check endpoint. Leave empty to disable health check."
+      }
+    },
     "appServiceSlotSettingConnectionStrings": {
       "type": "array",
       "defaultValue": [],
@@ -146,7 +153,8 @@
           "virtualApplications": "[parameters('appServiceVirtualApplications')]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
           "minTlsVersion": "1.2",
-          "ftpsState": "Disabled"
+          "ftpsState": "Disabled",
+          "healthCheckPath": "[parameters('healthCheckPath')]"
         },
         "httpsOnly": true
       },


### PR DESCRIPTION
## Context

This change is being made to implement the health check feature on an API when the required variable has been added to the DevOps library

## Guidance to review

This has been tested and peer reviewed.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
