### PR TITLE
DASD-11278/DASD-11279 - Implement minimum TLS version 1.2 into dasatsharedconfigstr and dasatsharedstr storage account

### DIFF
--- a/templates/storage-account-arm.json
+++ b/templates/storage-account-arm.json
@@ -90,7 +90,7 @@
         "TLS1_0",
         "TLS1_2"
       ],
-      "defaultValue": "TLS1_0"
+      "defaultValue": "TLS1_2"
     },
     "allowedHeaders": {
       "type": "array",


### PR DESCRIPTION
## Context

Update two shared storage accounts handled by platform building blocks. The storage accounts are:

dasatsharedconfigstr
dasatsharedstr 

## Changes proposed in this pull request

Set the default TLS value to 1_2

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
