### PR TITLE
added enableEncryptionAtHost property +semver: minor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.27
+
+Added encrypyion at host property on AKS and AKS node pools
+
 # 2.1.26
 
 Adding the health check property to app-service-v2.json

--- a/templates/aks-agent-pool.json
+++ b/templates/aks-agent-pool.json
@@ -107,6 +107,10 @@
       "metadata": {
         "description": "Default of 0 will apply the default osDisk size according to the vmSize specified."
       }
+    },
+    "enableEncryptionAtHost": {
+      "type": "bool",
+      "defaultValue": true
     }
   },
   "variables": {
@@ -122,7 +126,8 @@
       "orchestratorVersion": "[parameters('kubernetesVersion')]",
       "nodeLabels": "[parameters('nodeLabels')]",
       "nodeTaints": "[parameters('nodeTaints')]",
-      "maxPods": "[parameters('maxPods')]"
+      "maxPods": "[parameters('maxPods')]",
+      "enableEncryptionAtHost": "[parameters('enableEncryptionAtHost')]"
     },
     "withAutoscalingNodeProperties": {
       "enableAutoScaling": true,

--- a/templates/aks.json
+++ b/templates/aks.json
@@ -156,6 +156,10 @@
       "metadata": {
         "documentation": "https://docs.microsoft.com/en-us/azure/aks/api-server-authorized-ip-ranges"
       }
+    },
+    "enableEncryptionAtHost": {
+      "type": "bool",
+      "defaultValue": true
     }
   },
   "variables": {
@@ -169,7 +173,8 @@
           "mode": "System",
           "vnetSubnetID": "[variables('vnetSubnetID')]",
           "type": "VirtualMachineScaleSets",
-          "storageProfile": "ManagedDisks"
+          "storageProfile": "ManagedDisks",
+          "enableEncryptionAtHost": "[parameters('enableEncryptionAtHost')]"
         }
       ],
       "withoutMode": [
@@ -180,7 +185,8 @@
           "osType": "Linux",
           "vnetSubnetID": "[variables('vnetSubnetID')]",
           "type": "VirtualMachineScaleSets",
-          "storageProfile": "ManagedDisks"
+          "storageProfile": "ManagedDisks",
+          "enableEncryptionAtHost": "[parameters('enableEncryptionAtHost')]"
         }
       ]
     },


### PR DESCRIPTION
## Context
Enabling encryption at host, encrypts data at the VM level before it gets encrypted at rest, increasing security of the platform

## Changes proposed in this pull request

Option to enableEncryptionAtHost, setting the default to True as per the guidance from security team.

## Guidance to review

Check that new  pre-production AKS node pools have encryption at host enabled.

## Things to check

- [x] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [x] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
