### PR TITLE
DASD-12052 - Enforce TLS version to 1.2 for DAS cosmos accounts

### DIFF
--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
     "cosmosDbName": {
@@ -52,19 +52,6 @@
     "logAnalyticsWorkspaceResourceGroupName": {
       "type": "string",
       "defaultValue": ""
-    },
-    "minimalTlsVersion": {
-      "type": "string",
-      "metadata": {
-        "displayName": "Minimum TLS Version",
-        "description": "Minimum version of TLS required to access data in the cosmos db"
-      },
-      "allowedValues": [
-        "Tls",
-        "Tls11",
-        "Tls12"
-      ],
-      "defaultValue": "Tls12"
     }
   },
   "variables": {
@@ -150,7 +137,7 @@
     {
       "name": "[parameters('cosmosDbName')]",
       "type": "Microsoft.DocumentDB/databaseAccounts",
-      "apiVersion": "2024-05-15",
+      "apiVersion": "2023-11-15",
       "location": "[resourceGroup().location]",
       "kind": "[parameters('cosmosDbType')]",
       "properties": "[if(equals(parameters('cosmosDbType'), 'MongoDB'), variables('mongoCosmosProperties'), variables('baseCosmosProperties'))]",

--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -52,6 +52,19 @@
     "logAnalyticsWorkspaceResourceGroupName": {
       "type": "string",
       "defaultValue": ""
+    },
+    "minimalTlsVersion": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Minimum TLS Version",
+        "description": "Minimum version of TLS required to access data in the cosmos db"
+      },
+      "allowedValues": [
+        "Tls",
+        "Tls11",
+        "Tls12"
+      ],
+      "defaultValue": "Tls12"
     }
   },
   "variables": {
@@ -137,7 +150,7 @@
     {
       "name": "[parameters('cosmosDbName')]",
       "type": "Microsoft.DocumentDB/databaseAccounts",
-      "apiVersion": "2021-01-15",
+      "apiVersion": "2024-05-15",
       "location": "[resourceGroup().location]",
       "kind": "[parameters('cosmosDbType')]",
       "properties": "[if(equals(parameters('cosmosDbType'), 'MongoDB'), variables('mongoCosmosProperties'), variables('baseCosmosProperties'))]",

--- a/templates/cosmos-db.json
+++ b/templates/cosmos-db.json
@@ -52,6 +52,19 @@
     "logAnalyticsWorkspaceResourceGroupName": {
       "type": "string",
       "defaultValue": ""
+    },
+    "minimalTlsVersion": {
+      "type": "string",
+      "metadata": {
+        "displayName": "Minimal TLS Version",
+        "description": "Minimal version of TLS required to access cosmos db"
+      },
+      "allowedValues": [
+        "Tls",
+        "Tls11",
+        "Tls12"
+      ],
+      "defaultValue": "Tls12"
     }
   },
   "variables": {
@@ -75,7 +88,8 @@
           "locationName": "[resourceGroup().location]"
         }
       ],
-      "virtualNetworkRules": "[variables('virtualNetworkRules')]"
+      "virtualNetworkRules": "[variables('virtualNetworkRules')]",
+      "minimalTlsVersion": "[parameters('minimalTlsVersion')]"
     },
     "ipRangeFilterArray": "[split(parameters('ipRangeFilter'),',')]",
     "mongoCosmosProperties": "[union(variables('baseCosmosProperties'), variables('apiProperties'))]",


### PR DESCRIPTION
## Context

This change is needed to migrate all cosmos-db to TLS. This is because Microsoft are retiring TLS version 1.0 by the end of October. 

## Changes proposed in this pull request

None

## Guidance to review

Ensure a working pipeline is tested with these changes, the schema is ok and the now spelling errors.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
