### PR TITLE
DASD-11958 - Remediation - Azure Machine Learning Workspaces should disable public network access

### DIFF
--- a/templates/machine-learning-services/machine-learning-workspace.json
+++ b/templates/machine-learning-services/machine-learning-workspace.json
@@ -20,13 +20,16 @@
     "confidentialData": {
       "type": "bool",
       "defaultValue": true
+    },
+    "ipAllowlist": {
+      "type": "array"
     }
   },
   "variables": {},
   "resources": [
     {
       "type": "Microsoft.MachineLearningServices/workspaces",
-      "apiVersion": "2021-07-01",
+      "apiVersion": "2024-10-01-preview",
       "name": "[parameters('workspaceName')]",
       "location": "[resourceGroup().location]",
       "identity": {
@@ -39,7 +42,8 @@
         "applicationInsights": "[parameters('appInsightsResourceId')]",
         "containerRegistry": "[parameters('containerRegistryResourceId')]",
         "hbiWorkspace": "[parameters('confidentialData')]",
-        "systemDatastoresAuthMode": "identity"
+        "systemDatastoresAuthMode": "identity",
+        "ipAllowlist": "[parameters('ipAllowlist')]"
       }
     }
   ],


### PR DESCRIPTION
## Context

- To fufill sprint ticket https://skillsfundingagency.atlassian.net/jira/software/c/projects/DASD/boards/391?selectedIssue=DASD-11958

- To support only internal Department of Education IP's addresses when accessing the machine learning workspace on Azure 

## Changes proposed in this pull request

- Update the Microsoft.MachineLearningServices/workspaces resource to an API that  supports IP whitelisting

- Introduce ARM param with a variable set in the environment specific variable group, giving control over what IP should access the resource on each environment. 

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
