### PR TITLE
added app insights failed requests alert and get product step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 2.3.0
+# 2.2.13
+
+Added applicaton insights failed request template and get product app insights infomation step
+
+# 2.2.3
 
 Setting default value of WEBSITE_ADD_SITENAME_BINDINGS_IN_APPHOST_CONFIG to 1
 

--- a/azure-pipelines-templates/deploy/step/get-product-app-insights.yml
+++ b/azure-pipelines-templates/deploy/step/get-product-app-insights.yml
@@ -1,0 +1,21 @@
+parameters:
+  ServiceConnection:
+  AppInsightsResourceGroup:
+  AppInsightsName:
+  IsMultiRepoCheckout: false
+
+steps:
+- checkout: das-platform-automation
+- task: AzurePowerShell@5
+  displayName: Get-ProductApplicationInsights
+  inputs:
+    azureSubscription: ${{ parameters.ServiceConnection }}
+    ${{ if eq(parameters.IsMultiRepoCheckout, false) }}:
+      scriptPath: Infrastructure-Scripts/Get-ProductApplicationInsights.ps1
+    ${{ if eq(parameters.IsMultiRepoCheckout, true) }}:
+      scriptPath: das-platform-automation/Infrastructure-Scripts/Get-ProductApplicationInsights.ps1
+    scriptArguments:
+      -AppInsightsResourceGroup ${{ parameters.AppInsightsResourceGroup }} `
+      -AppInsightsName ${{ parameters.AppInsightsName }}
+    azurePowerShellVersion: LatestVersion
+    pwsh: true

--- a/templates/application-insights-failed-requests-alert.json
+++ b/templates/application-insights-failed-requests-alert.json
@@ -1,0 +1,171 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "enabled": {
+            "type": "bool",
+            "defaultValue": true
+        },
+        "serviceName": {
+            "type": "string",
+            "metadata": {
+                "description": "The web app name that the alert is applied for"
+            }
+        },
+        "applicationInsightsResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "The application insights resource ID that the alert is applied on"
+            }
+        },
+        "alertActionGroupResourceId": {
+            "type": "string",
+            "metadata": {
+                "description": "The id of the action group to send the alert to."
+            }
+        },
+        "alertSeverity": {
+            "type": "int",
+            "defaultValue": 0,
+            "allowedValues": [
+                0,
+                1,
+                2,
+                3,
+                4
+            ],
+            "metadata": {
+                "description": "Severity of alert {0,1,2,3,4}"
+            }
+        },
+        "windowSize": {
+            "type": "string",
+            "defaultValue": "PT15M",
+            "allowedValues": [
+                "PT1M",
+                "PT5M",
+                "PT15M",
+                "PT30M",
+                "PT1H",
+                "PT6H",
+                "PT12H",
+                "P1D"
+            ],
+            "metadata": {
+                "description": "Period of time used to monitor alert activity based on the threshold. Must be between one minute and one day. ISO 8601 duration format."
+            }
+        },
+        "evaluationFrequency": {
+            "type": "string",
+            "defaultValue": "PT1M",
+            "allowedValues": [
+                "PT1M",
+                "PT5M",
+                "PT15M",
+                "PT30M",
+                "PT1H"
+            ],
+            "metadata": {
+                "description": "How often the metric alert is evaluated. ISO 8601 duration format."
+            }
+        },
+        "dimensions": {
+            "type": "array",
+            "metadata": {
+                "description": "An array of metric dimensions used to filter the metric being alerted on",
+                "documentation": "https://docs.microsoft.com/en-us/azure/templates/microsoft.insights/metricalerts?tabs=json#metricdimension"
+            },
+            "defaultValue": [
+                {
+                    "name": "request/resultCode",
+                    "operator": "Include",
+                    "values": [
+                        "500",
+                        "501",
+                        "502",
+                        "503",
+                        "504",
+                        "505",
+                        "506",
+                        "507",
+                        "508",
+                        "509"
+                    ]
+                },
+                {
+                    "name": "cloud/roleName",
+                    "operator": "Include",
+                    "values": [
+                        "[parameters('serviceName')]"
+                    ]
+                }
+            ]
+        },
+        "alertSensitivity": {
+            "type": "string",
+            "defaultValue": "Medium",
+            "metadata": {
+                "description": "The Dynamic threshold sensitivity"
+            }
+        },
+        "numberOfEvaluationPeriods": {
+            "type": "int",
+            "defaultValue": 2
+        },
+        "minFailingPeriodsToAlert": {
+            "type": "int",
+            "defaultValue": 2
+        }
+    },
+    "variables": {
+        "alertName": "[concat(parameters('serviceName'),' Failed Requests Alert')]"
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Insights/metricAlerts",
+            "apiVersion": "2018-03-01",
+            "name": "[variables('alertName')]",
+            "location": "global",
+            "tags": {},
+            "properties": {
+                "severity": "[parameters('alertSeverity')]",
+                "enabled": "[parameters('enabled')]",
+                "scopes": [
+                    "[parameters('applicationInsightsResourceId')]"
+                ],
+                "evaluationFrequency": "[parameters('evaluationFrequency')]",
+                "windowSize": "[parameters('windowSize')]",
+                "criteria": {
+                    "allOf": [
+                        {
+                            "alertSensitivity": "[parameters('alertSensitivity')]",
+                            "failingPeriods": {
+                                "numberOfEvaluationPeriods": "[parameters('numberOfEvaluationPeriods')]",
+                                "minFailingPeriodsToAlert": "[parameters('minFailingPeriodsToAlert')]"
+                            },
+                            "name": "failedRequests",
+                            "metricNamespace": "microsoft.insights/components",
+                            "metricName": "requests/failed",
+                            "dimensions": "[parameters('dimensions')]",
+                            "operator": "GreaterOrLessThan",
+                            "timeAggregation": "Count",
+                            "skipMetricValidation": false,
+                            "criterionType": "DynamicThresholdCriterion"
+                        }
+                    ],
+                    "odata.type": "Microsoft.Azure.Monitor.MultipleResourceMultipleMetricCriteria"
+                },
+                "autoMitigate": true,
+                "targetResourceType": "microsoft.insights/components",
+                "targetResourceRegion": "westeurope",
+                "actions": [
+                    {
+                        "actionGroupId": "[parameters('alertActionGroupResourceId')]",
+                        "webHookProperties": {}
+                    }
+                ]
+            }
+        }
+    ],
+    "outputs": {}
+}


### PR DESCRIPTION
## Context

- Added application insights failed request alert.
- Added get product pipeline template step. This retrieves information of the application insights used to apply the app insights alert.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
