### PR TITLE
added templates for apim app insights logger persistence

### DIFF
--- a/templates/apim/apim-service-named-value.json
+++ b/templates/apim/apim-service-named-value.json
@@ -1,0 +1,35 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "apimName": {
+            "type": "string"
+        },
+        "keyVaultSecretId": {
+            "type": "string"
+        },
+        "namedValueName": {
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.ApiManagement/service/namedValues",
+            "name": "[concat(parameters('apimName'), '/', parameters('namedValueName'))]",
+            "apiVersion": "2024-06-01-preview",
+            "properties": {
+                "displayName": "[parameters('namedValueName')]",
+                "keyVault": {
+                    "secretIdentifier": "[parameters('keyVaultSecretId')]"
+                },
+                "secret": true
+            }
+        }
+    ],
+    "outputs": {
+        "namedValueName": {
+            "type": "string",
+            "value": "[reference(resourceId('Microsoft.ApiManagement/service/namedValues', parameters('apimName'), parameters('namedValueName')), '2024-06-01-preview', 'Full').properties.displayName]"
+        }
+    }
+}

--- a/templates/apim/apim-service.json
+++ b/templates/apim/apim-service.json
@@ -203,5 +203,11 @@
         }
       }
     }
-  ]
+  ],
+  "outputs":{
+    "managedServiceIdentityId": {
+      "type": "string",
+      "value": "[reference(parameters('apimName'), '2019-12-01', 'Full').identity.principalId]"
+    }
+  }
 }

--- a/templates/keyvault-secret.json
+++ b/templates/keyvault-secret.json
@@ -23,5 +23,10 @@
       }
     }
   ],
-  "outputs": {}
+  "outputs": {
+    "keyVaultSecretId": {
+      "type": "string",
+      "value": "[reference(resourceId('Microsoft.KeyVault/vaults/secrets', parameters('keyVaultName'), parameters('secretName')), '2018-02-14', 'Full').properties.secretUriWithVersion]"
+    }
+  }
 }

--- a/templates/role-assignments/role-assignment-app-insights.json
+++ b/templates/role-assignments/role-assignment-app-insights.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "principalId": {
+      "type": "string"
+    },
+    "assignmentType": {
+      "type": "string",
+      "allowedValues": [
+        "Monitoring Metrics Publisher"
+      ]
+    },
+    "resourceName": {
+      "type": "string"
+    }
+  },
+  "variables": {
+    "Monitoring Metrics Publisher": "[concat('/subscriptions/', subscription().subscriptionId, '/providers/Microsoft.Authorization/roleDefinitions/', '3913510d-42f4-4e42-8a64-420c390055eb')]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid(uniqueString(parameters('resourceName'), variables(parameters('assignmentType')), parameters('principalId')))]",
+      "scope": "[concat(resourceGroup().id, '/providers/microsoft.insights/components/', parameters('resourceName'))]",
+      "properties": {
+        "roleDefinitionId": "[variables(parameters('assignmentType'))]",
+        "principalId": "[parameters('principalId')]"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Context

Added outputs to existing templates and added 2 templates for apim named value and role assignment to deploy and assigned a named value with a secret from key vault.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
