### PR TITLE
added runtime sql admin secret fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+This change allows the SQL server password to be fetched during pipeline runtime to allow easier rotation of the secret.
+
+Breaking change to [sql-dacpac-deploy.yml](azure-pipelines-templates/deploy/step/sql-dacpac-deploy.yml). Removed ```${{ parameters.SqlPassword }}``` which is passed into template from service pipelines, no longer required when using AZ CLI. Any pipeline using this template will need to remove the parameter before bumping to this version.
+
 # 2.2.13
 
 Added applicaton insights failed request template and get product app insights infomation step

--- a/azure-pipelines-templates/deploy/step/sql-dacpac-deploy.yml
+++ b/azure-pipelines-templates/deploy/step/sql-dacpac-deploy.yml
@@ -16,7 +16,6 @@ parameters:
   type: boolean
 - name: ServerName
 - name: SqlUsername
-- name: SqlPassword
 
 steps:
 # this task requires that a pipeline variable is set in the Azure DevOps UI, see Approve-SqlDacpacDeploymentDataLoss docs for more info.
@@ -26,6 +25,16 @@ steps:
     filePath: das-platform-automation/Infrastructure-Scripts/Approve-SqlDacpacDeploymentDataLoss.ps1
     # note: double dollar sign ($$) converts Azure DevOps boolean to PowerShell boolean by prefixing the True\False string with a dollar sign
     arguments: -Environment ${{ parameters.Environment }} -OverrideBlockOnPossibleDataLoss $${{ parameters.OverrideBlockOnPossibleDataLoss }} -Verbose
+- task: AzurePowerShell@5
+  displayName: 'Fetch SQL Server Admin password from key vault'
+  inputs:
+    azureSubscription: ${{ parameters.AzureSubscription }}
+    scriptType: inlineScript
+    inline: |
+      $SharedSqlServerAdminPassword = Get-AzKeyVaultSecret -VaultName $(SharedKeyVaultName) -Name $(SharedSQLServerName) -AsPlainText
+      Write-Output "Setting variable SharedSqlServerAdminPassword"
+      Write-Output "##vso[task.setvariable variable=SharedSqlServerAdminPassword;isreadonly=true;issecret=true]$SharedSqlServerAdminPassword"
+    azurePowerShellVersion: LatestVersion
 - task: SqlAzureDacpacDeployment@1
   condition: and(succeeded(), ne(variables.SetBlockOnPossibleDataLossArgument, true))
   displayName: Execute Azure SQL DacpacTask without AdditionalArguments
@@ -34,7 +43,7 @@ steps:
     ServerName: ${{ parameters.ServerName }}
     DatabaseName: ${{ parameters.DatabaseName }}
     SqlUsername: ${{ parameters.SqlUsername }}
-    SqlPassword: ${{ parameters.SqlPassword }}
+    SqlPassword: $(SharedSqlServerAdminPassword)
     DacpacFile: ${{ parameters.DacpacFile }}
 - task: SqlAzureDacpacDeployment@1
   condition: and(succeeded(), eq(variables.SetBlockOnPossibleDataLossArgument, true))
@@ -44,6 +53,6 @@ steps:
     ServerName: ${{ parameters.ServerName }}
     DatabaseName: ${{ parameters.DatabaseName }}
     SqlUsername: ${{ parameters.SqlUsername }}
-    SqlPassword: ${{ parameters.SqlPassword }}
+    SqlPassword: $(SharedSqlServerAdminPassword)
     DacpacFile: ${{ parameters.DacpacFile }}
     AdditionalArguments: /p:BlockOnPossibleDataLoss=false


### PR DESCRIPTION
## Context

This change is to allow rotation of the SQL server password to be much easier. By fetching the key vault secret during runtime, we don't have to manually update variable groups and redeploy pipelines, instead pipelines will fetch the secret on every run. When the secret is rotated and key vault secret is updated, the pipeline will fetch the latest version of the secret, reducing the chance of downtime to DACPAC deployments.

## Changes proposed in this pull request

- Added script to fetch key vault secret and set azure devops secret.
- Removed old parameter (**Breaking Change**)

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
