### PR TITLE
Create private-linked-scoped-resource.json

### DIFF
--- a/templates/private-linked-scoped-resource.json
+++ b/templates/private-linked-scoped-resource.json
@@ -1,0 +1,32 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "appInsightsName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the application insights resource"
+            }
+        },
+        "privateLinkScopeName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the Private Link Scope"
+            }
+        },
+        "appInsightsResourceId": {
+            "defaultValue": "",
+            "type": "string"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Insights/privateLinkScopes/scopedResources",
+            "apiVersion": "2021-09-01",
+            "name": "[concat(parameters('privateLinkScopeName'), '/', parameters('appInsightsName'), '-connection')]",
+            "properties": {
+                "linkedResourceId": "[parameters('appInsightsResourceId')]"
+            }
+        }
+    ]
+}

--- a/templates/private-linked-scoped-resource.json
+++ b/templates/private-linked-scoped-resource.json
@@ -2,7 +2,7 @@
     "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
     "contentVersion": "1.0.0.0",
     "parameters": {
-        "appInsightsName": {
+        "scopedResourceName": {
             "type": "string",
             "metadata": {
                 "description": "Name of the application insights resource"
@@ -14,7 +14,7 @@
                 "description": "Name of the Private Link Scope"
             }
         },
-        "appInsightsResourceId": {
+        "scopedResourceId": {
             "defaultValue": "",
             "type": "string"
         }
@@ -23,9 +23,9 @@
         {
             "type": "Microsoft.Insights/privateLinkScopes/scopedResources",
             "apiVersion": "2021-09-01",
-            "name": "[concat(parameters('privateLinkScopeName'), '/', parameters('appInsightsName'), '-connection')]",
+            "name": "[concat(parameters('privateLinkScopeName'), '/', parameters('scopedResourceName'), '-connection')]",
             "properties": {
-                "linkedResourceId": "[parameters('appInsightsResourceId')]"
+                "linkedResourceId": "[parameters('scopedResourceId')]"
             }
         }
     ]


### PR DESCRIPTION
## Context

To standardize and automate the private link integration for Azure Monitor

## Changes proposed in this pull request

For the purposes of updating all ARM templates that contain Application Insights resources and linking them to their respective Azure Monitor Private Link Scopes (AMPLS) using the linkedResourceId property.
