### PR TITLE
added routes property to route table

### DIFF
--- a/templates/route-table.json
+++ b/templates/route-table.json
@@ -13,6 +13,13 @@
             "metadata": {
                 "description": "Indicates whether BGP route propagation is disabled"
             }
+        },
+        "routeTableRoutes": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Array of routes to be added to route table"
+            }
         }
     },
     "variables": {},
@@ -23,7 +30,8 @@
             "name": "[parameters('routeTableName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "disableBgpRoutePropagation": "[parameters('disableBgpRoutePropagation')]"
+                "disableBgpRoutePropagation": "[parameters('disableBgpRoutePropagation')]",
+                "routes": "[parameters('routeTableRoutes')]"
             },
             "tags": {}
         }


### PR DESCRIPTION
Added routes property to route table template to allow deployment of routes with route table in ARM. If no routes are passed in then default value of no routes will be used to deploy the route table.

