### PR TITLE
DASD-13265 - Switch to Portable Bouncy Castle Nuget package for Pull request commenting task

### DIFF
--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -90,12 +90,13 @@ steps:
     $null = Install-Package -Name "Octokit" -RequiredVersion "4.0.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
     $null = Install-Package -Name "GitHubJwt" -RequiredVersion "0.0.5" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
     $null = Install-Package -Name "jose-jwt" -RequiredVersion "4.0.1" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
-    $null = Install-Package -Name "BouncyCastle.NetCore" -RequiredVersion "1.9.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+    $null = Install-Package -Name "Portable.BouncyCastle" -RequiredVersion "1.9.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+
 
     $OctokitDll = "$(Agent.TempDirectory)/packages/Octokit.4.0.0/lib/netstandard2.0/Octokit.dll"
     $GitHubJwtDll = "$(Agent.TempDirectory)/packages/GitHubJwt.0.0.5/lib/netstandard2.0/GitHubJwt.dll"
     $JoseJwtDll = "$(Agent.TempDirectory)/packages/jose-jwt.4.0.1/lib/netstandard2.1/jose-jwt.dll"
-    $BouncyCastleCryptoDll = "$(Agent.TempDirectory)/packages/BouncyCastle.NetCore.1.9.0/lib/netstandard2.0/BouncyCastle.Crypto.dll"
+    $BouncyCastleCryptoDll = "$(Agent.TempDirectory)/packages/Portable.BouncyCastle.1.9.0/lib/netstandard2.0/BouncyCastle.Crypto.dll"
 
     $null = Add-Type -Path $OctokitDll
     $null = Add-Type -Path $GitHubJwtDll


### PR DESCRIPTION
## Context

The pull request commenting task has seemed to fail in a couple pipeline runs pointing to the Nuget Package Bouncy Castle being an issue. The fact that this package is now deprecated and it is now recommended to use Portable Bouncy Castle as it is supported and actively maintained drifted us to switch to using this package instead. 

## Changes proposed in this pull request

The pull request commenting task in the app build template will switch from installing BouncyCastle.NetCore Nuget pkg to Portable.BouncyCastle Nuget pkg.

## Guidance to review

This was tested in a pipeline run with das-assessor-functions:
[Pipeline Run](https://dev.azure.com/sfa-gov-uk/Digital%20Apprenticeship%20Service/_build/results?buildId=931883&view=logs&j=0103e41a-f776-5c76-ec92-87a9d94e5e45&t=fa0ebd1a-a924-5196-b862-cb3308f3acc7
)
