### PR TITLE
Updated app build to remove pull request commenting

### DIFF
--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -77,50 +77,50 @@ steps:
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
 
-- task: DownloadSecureFile@1
-  name: DownloadDasGitHubAppPrivateKey
-  displayName: 'Download DAS GitHub App private key'
-  inputs:
-    secureFile: 'das-github-app-private-key.pem'
+# - task: DownloadSecureFile@1
+#   name: DownloadDasGitHubAppPrivateKey
+#   displayName: 'Download DAS GitHub App private key'
+#   inputs:
+#     secureFile: 'das-github-app-private-key.pem'
 
-- pwsh: |
-    $null = Register-PackageSource -Name NuGet -Location https://api.nuget.org/v3/index.json -ProviderName NuGet
-    #NOTE: Install-Package with -SkipDependencies flag used until PowerShellGet v3 can be used to only install Octokit and GitHubJwt along with their dependencies.
-    #NOTE: https://github.com/PowerShell/PowerShellGet/issues/487#issue-1000366159
-    $null = Install-Package -Name "Octokit" -RequiredVersion "4.0.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
-    $null = Install-Package -Name "GitHubJwt" -RequiredVersion "0.0.5" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
-    $null = Install-Package -Name "jose-jwt" -RequiredVersion "4.0.1" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
-    $null = Install-Package -Name "Portable.BouncyCastle" -RequiredVersion "1.9.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+# - pwsh: |
+#     $null = Register-PackageSource -Name NuGet -Location https://api.nuget.org/v3/index.json -ProviderName NuGet
+#     #NOTE: Install-Package with -SkipDependencies flag used until PowerShellGet v3 can be used to only install Octokit and GitHubJwt along with their dependencies.
+#     #NOTE: https://github.com/PowerShell/PowerShellGet/issues/487#issue-1000366159
+#     $null = Install-Package -Name "Octokit" -RequiredVersion "4.0.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+#     $null = Install-Package -Name "GitHubJwt" -RequiredVersion "0.0.5" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+#     $null = Install-Package -Name "jose-jwt" -RequiredVersion "4.0.1" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
+#     $null = Install-Package -Name "Portable.BouncyCastle" -RequiredVersion "1.9.0" -Destination "$(Agent.TempDirectory)/packages" -Source "NuGet" -Force -SkipDependencies
 
 
-    $OctokitDll = "$(Agent.TempDirectory)/packages/Octokit.4.0.0/lib/netstandard2.0/Octokit.dll"
-    $GitHubJwtDll = "$(Agent.TempDirectory)/packages/GitHubJwt.0.0.5/lib/netstandard2.0/GitHubJwt.dll"
-    $JoseJwtDll = "$(Agent.TempDirectory)/packages/jose-jwt.4.0.1/lib/netstandard2.1/jose-jwt.dll"
-    $BouncyCastleCryptoDll = "$(Agent.TempDirectory)/packages/Portable.BouncyCastle.1.9.0/lib/netstandard2.0/BouncyCastle.Crypto.dll"
+#     $OctokitDll = "$(Agent.TempDirectory)/packages/Octokit.4.0.0/lib/netstandard2.0/Octokit.dll"
+#     $GitHubJwtDll = "$(Agent.TempDirectory)/packages/GitHubJwt.0.0.5/lib/netstandard2.0/GitHubJwt.dll"
+#     $JoseJwtDll = "$(Agent.TempDirectory)/packages/jose-jwt.4.0.1/lib/netstandard2.1/jose-jwt.dll"
+#     $BouncyCastleCryptoDll = "$(Agent.TempDirectory)/packages/Portable.BouncyCastle.1.9.0/lib/netstandard2.0/BouncyCastle.Crypto.dll"
 
-    $null = Add-Type -Path $OctokitDll
-    $null = Add-Type -Path $GitHubJwtDll
-    $null = Add-Type -Path $JoseJwtDll
-    $null = Add-Type -Path $BouncyCastleCryptoDll
+#     $null = Add-Type -Path $OctokitDll
+#     $null = Add-Type -Path $GitHubJwtDll
+#     $null = Add-Type -Path $JoseJwtDll
+#     $null = Add-Type -Path $BouncyCastleCryptoDll
 
-    $PrivateKey = [GitHubJwt.FilePrivateKeySource]::new("$(DownloadDasGitHubAppPrivateKey.secureFilePath)")
-    $GitHubJwtFactoryOptions = [GitHubJwt.GitHubJwtFactoryOptions]::new()
-    $GitHubJwtFactoryOptions.AppIntegrationId = $(DasGitHubAppId)
-    $GitHubJwtFactoryOptions.ExpirationSeconds = 60
-    $Generator = [GitHubJwt.GitHubJwtFactory]::new($PrivateKey, $GitHubJwtFactoryOptions)
-    $JwtToken = $Generator.CreateEncodedJwtToken()
+#     $PrivateKey = [GitHubJwt.FilePrivateKeySource]::new("$(DownloadDasGitHubAppPrivateKey.secureFilePath)")
+#     $GitHubJwtFactoryOptions = [GitHubJwt.GitHubJwtFactoryOptions]::new()
+#     $GitHubJwtFactoryOptions.AppIntegrationId = $(DasGitHubAppId)
+#     $GitHubJwtFactoryOptions.ExpirationSeconds = 60
+#     $Generator = [GitHubJwt.GitHubJwtFactory]::new($PrivateKey, $GitHubJwtFactoryOptions)
+#     $JwtToken = $Generator.CreateEncodedJwtToken()
 
-    $AppClient = [Octokit.GitHubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app"))
-    $AppClient.Credentials = [Octokit.Credentials]::new($JwtToken, ([Octokit.AuthenticationType]::Bearer))
-    $Response = $AppClient.GitHubApps.CreateInstallationToken($(DasGitHubAppInstallationId)).Result
+#     $AppClient = [Octokit.GitHubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app"))
+#     $AppClient.Credentials = [Octokit.Credentials]::new($JwtToken, ([Octokit.AuthenticationType]::Bearer))
+#     $Response = $AppClient.GitHubApps.CreateInstallationToken($(DasGitHubAppInstallationId)).Result
 
-    $PullRequestComment = "Please remember to check any packages used by this application to ensure they are up to date @$(Build.SourceVersionAuthor). cc/ $(PullRequestVulnerabilitiesDetectedTaggedUsers)"
+#     $PullRequestComment = "Please remember to check any packages used by this application to ensure they are up to date @$(Build.SourceVersionAuthor). cc/ $(PullRequestVulnerabilitiesDetectedTaggedUsers)"
 
-    $InstallationClient = [Octokit.GithubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app-installation"))
-    $InstallationClient.Credentials = [Octokit.Credentials]::new($Response.Token)
-    $InstallationClient.Issue.Comment.Create("$(Build.Repository.Name)".Split('/')[0], "$(Build.Repository.Name)".Split('/')[1], $(System.PullRequest.PullRequestNumber), $PullRequestComment)
-  displayName: Pull Request Commenting
-  condition: and(succeeded(), eq(variables.VulnerablePackagesDetected, 'true'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables.PullRequestVulnerabilitiesCommentTaskEnabled, 'true'))
+#     $InstallationClient = [Octokit.GithubClient]::new([Octokit.ProductHeaderValue]::new("das-github-app-installation"))
+#     $InstallationClient.Credentials = [Octokit.Credentials]::new($Response.Token)
+#     $InstallationClient.Issue.Comment.Create("$(Build.Repository.Name)".Split('/')[0], "$(Build.Repository.Name)".Split('/')[1], $(System.PullRequest.PullRequestNumber), $PullRequestComment)
+#   displayName: Pull Request Commenting
+#   condition: and(succeeded(), eq(variables.VulnerablePackagesDetected, 'true'), eq(variables['Build.Reason'], 'PullRequest'), eq(variables.PullRequestVulnerabilitiesCommentTaskEnabled, 'true'))
 
 - task: DotNetCoreCLI@2
   displayName: Build


### PR DESCRIPTION

## Context

The existing pull request commenting step was causing issues during package installation due to dependency conflicts when loading GitHub-related libraries (`Octokit`, `GitHubJwt`, etc.). This was interrupting the pipeline and preventing successful builds, even though the comment was a non-essential enhancement.

## Changes proposed in this pull request

* **Commented out** the GitHub App private key download and pull request commenting PowerShell steps.
* This change temporarily disables automated PR comments related to vulnerable packages until a more stable or modern implementation can be put in place.

---