### PR TITLE
Add .net10 as an allowed value for FA deployment

### DIFF
--- a/templates/function-app-v2.json
+++ b/templates/function-app-v2.json
@@ -61,7 +61,8 @@
       "allowedValues": [
         "",
         "v6.0",
-        "v8.0"
+        "v8.0",
+        "v10.0"
       ],
       "metadata": {
         "description": ".NET version of project, e.g. v6.0, needed for runtime version ~4 onwards",


### PR DESCRIPTION
Enable .NET 10 version on Function App Deployments