### PR TITLE
DASD-14624 - Pipeline - Stop pipeline run on high or critical alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 3.2.0
+
+DASD-14624: Updated `app-build.yml` package scanning to fail the pipeline when High or Critical severity NuGet vulnerabilities are detected.
+
+A new "Fail on High or Critical Severity Vulnerabilities" step has been added after the existing "Package Scanning" step. This step runs with `continueOnError: false` and will always fail the pipeline when High or Critical severity packages are found, regardless of the `ContinueOnVulnerablePackageScanError` parameter. Low and Moderate severity vulnerabilities continue to be controlled by that parameter.
+
+**Note:** Pipelines that previously set `ContinueOnVulnerablePackageScanError: true` to suppress all vulnerability failures will now fail if any High or Critical severity packages are present.
+
 # 3.1.0
 
 DASD-12494: CDN migration from Edgio to Azure Front Door. Added `afd-profile.json` and `afd-endpoint.json` to support Azure Front Door resources.

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -95,25 +95,15 @@ steps:
     }
 
     if ($HighCriticalVulnerabilities.Count -gt 0) {
-      Write-Host "##vso[task.logissue type=error]High or Critical severity NuGet package vulnerabilities detected. The pipeline has been failed to ensure security incidents are resolved proactively."
-      Write-Host ""
-      Write-Host "The following packages have High or Critical severity vulnerabilities:"
-      Write-Host ""
-      $HighCriticalVulnerabilities | ForEach-Object {
+      $formattedLines = $HighCriticalVulnerabilities | ForEach-Object {
         $parts = $_ -split '\s+'
         $packageName = $parts[1]
         $advisoryUrl = $parts[-1]
         $fixedVersion = Get-FixedVersion -AdvisoryUrl $advisoryUrl -PackageName $packageName
         $fixText = if ($fixedVersion) { " (fix available: >= $fixedVersion)" } else { "" }
-        Write-Host "  $_$fixText"
+        "  $_$fixText"
       }
-      Write-Host ""
-      Write-Host "Actions required:"
-      Write-Host "  1. Update the affected packages to a secure version"
-      Write-Host "  2. If no fix is available, assess the risk and consider alternative packages"
-      Write-Host "  3. Re-run the pipeline once the packages have been updated"
-      Write-Host ""
-      Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
+      $formattedLines | Set-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-packages.txt"
       Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]true"
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
       $(exit 1)
@@ -132,8 +122,22 @@ steps:
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
 
-- pwsh: exit 1
-  displayName: Fail on High or Critical Severity Vulnerabilities
+- pwsh: |
+    $packages = Get-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-packages.txt"
+    Write-Host "##vso[task.logissue type=error]High or Critical severity NuGet package vulnerabilities detected. The pipeline has been failed to ensure security incidents are resolved proactively."
+    Write-Host ""
+    Write-Host "The following packages require immediate attention:"
+    Write-Host ""
+    $packages | ForEach-Object { Write-Host $_ }
+    Write-Host ""
+    Write-Host "Actions required:"
+    Write-Host "  1. Update the affected packages to a secure version"
+    Write-Host "  2. If no fix is available, assess the risk and consider alternative packages"
+    Write-Host "  3. Re-run the pipeline once the packages have been updated"
+    Write-Host ""
+    Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
+    exit 1
+  displayName: High/Critical Severity Vulnerabilities
   condition: and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))
 
 - task: DownloadSecureFile@1

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -50,9 +50,11 @@ steps:
     $TargetPatterns = "${{ parameters.TargetProjects }}".Trim().Split("`n")
     $TargetPatterns
     $ErrorFound = $false
+    $HighCriticalVulnerabilities = [System.Collections.Generic.List[string]]::new()
     $TargetPatterns | ForEach-Object {
       $Projects = Get-ChildItem -Path $_ -Recurse
       foreach ($Project in $Projects) {
+        $Vulnerable = @()
         dotnet list $Project package --deprecated | Tee-Object -Variable Deprecated
         if (([Version](dotnet --version)).Major -ge 5) {
           dotnet list $Project package --vulnerable --include-transitive | Tee-Object -Variable Vulnerable
@@ -62,20 +64,49 @@ steps:
         if ($Errors.Count -gt 0) {
           $ErrorFound = $true
         }
+
+        $Vulnerable | Select-String '>' | Where-Object { $_ -match '\b(High|Critical)\b' } | ForEach-Object {
+          $HighCriticalVulnerabilities.Add($_.Line.Trim())
+        }
       }
     }
 
-    if($ErrorFound){
-        Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
-        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
-        $(exit 1)
+    if ($HighCriticalVulnerabilities.Count -gt 0) {
+      $HighCriticalVulnerabilities | Set-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-vulnerabilities.txt"
+      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]true"
+    } else {
+      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]false"
     }
-    else {
-        Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
-        $(exit 0)
+
+    if ($ErrorFound) {
+      Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
+      Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
+      $(exit 1)
+    } else {
+      Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
+      $(exit 0)
     }
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
+
+- pwsh: |
+    $highCriticalDetails = Get-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-vulnerabilities.txt"
+    Write-Host ""
+    Write-Host "##vso[task.logissue type=error]High or Critical severity NuGet package vulnerabilities detected. The pipeline has been failed to ensure security incidents are resolved proactively."
+    Write-Host ""
+    Write-Host "The following packages have High or Critical severity vulnerabilities:"
+    Write-Host ""
+    $highCriticalDetails | ForEach-Object { Write-Host "  $_" }
+    Write-Host ""
+    Write-Host "Actions required:"
+    Write-Host "  1. Update the affected packages to a secure version"
+    Write-Host "  2. If no fix is available, assess the risk and consider alternative packages"
+    Write-Host "  3. Re-run the pipeline once the packages have been updated"
+    Write-Host ""
+    Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
+    exit 1
+  displayName: Fail on High or Critical Severity Vulnerabilities
+  condition: and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -37,7 +37,7 @@ steps:
 
 - task: DotNetCoreCLI@2
   condition: ne('${{ parameters.AzureArtifactsFeed }}', '')
-  displayName: Restore - Including Custom Feed
+  displayName: Restore (Custom Feed)
   inputs:
     command: restore
     projects: ${{ parameters.TargetProjects }}

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -114,20 +114,27 @@ steps:
       Write-Host "  3. Re-run the pipeline once the packages have been updated"
       Write-Host ""
       Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
+      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]true"
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
       $(exit 1)
     }
     elseif ($ErrorFound) {
       Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
+      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]false"
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
       $(exit 1)
     }
     else {
+      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]false"
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
       $(exit 0)
     }
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
+
+- pwsh: exit 1
+  displayName: Fail on High or Critical Severity Vulnerabilities
+  condition: and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -12,7 +12,7 @@ parameters:
 
 steps:
 - task: SonarCloudPrepare@3
-  displayName: Prepare SonarCloud analysis configuration
+  displayName: SonarCloud Prepare
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     SonarCloud: ESFA - SonarCloud
@@ -266,11 +266,11 @@ steps:
     arguments: '--configuration $(buildConfiguration) --no-build  /p:CollectCoverage=true /p:CoverletOutput=$(Agent.TempDirectory)/CoverageResults/ /p:MergeWith=$(Agent.TempDirectory)/CoverageResults/coverage.json /p:CoverletOutputFormat="opencover%2cjson"'
 
 - task: SonarCloudAnalyze@3
-  displayName: Run SonarCloud analysis
+  displayName: SonarCloud Analyse
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
 
 - task: SonarCloudPublish@3
-  displayName: Publish SonarCloud analysis results on build summary
+  displayName: SonarCloud Publish
   condition: and(succeeded(), or(in(variables['Build.SourceBranch'], 'refs/heads/master', 'refs/heads/main'), eq(variables['Build.Reason'], 'PullRequest')), eq(${{ parameters.SonarCloud }}, true))
   inputs:
     pollingTimeoutSec: '300'

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -51,6 +51,29 @@ steps:
     $TargetPatterns
     $ErrorFound = $false
     $HighCriticalVulnerabilities = [System.Collections.Generic.List[string]]::new()
+
+    function Get-FixedVersion {
+      param([string]$AdvisoryUrl, [string]$PackageName)
+      try {
+        if ($AdvisoryUrl -notmatch 'advisories/(GHSA-[a-z0-9-]+)') { return $null }
+        $ghsaId = $Matches[1]
+        $osvResponse = Invoke-RestMethod -Method GET `
+          -Uri "https://api.osv.dev/v1/vulns/$ghsaId" `
+          -TimeoutSec 5 `
+          -ErrorAction Stop
+        $fixedVersions = $osvResponse.affected |
+          Where-Object { $_.package.ecosystem -eq 'NuGet' -and $_.package.name -ieq $PackageName } |
+          ForEach-Object { $_.ranges } |
+          ForEach-Object { $_.events } |
+          Where-Object { $null -ne $_.fixed } |
+          Select-Object -ExpandProperty fixed
+        return ($fixedVersions | Select-Object -Last 1)
+      }
+      catch {
+        return $null
+      }
+    }
+
     $TargetPatterns | ForEach-Object {
       $Projects = Get-ChildItem -Path $_ -Recurse
       foreach ($Project in $Projects) {
@@ -72,41 +95,39 @@ steps:
     }
 
     if ($HighCriticalVulnerabilities.Count -gt 0) {
-      $HighCriticalVulnerabilities | Set-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-vulnerabilities.txt"
-      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]true"
-    } else {
-      Write-Output "##vso[task.setvariable variable=HighCriticalVulnerabilitiesDetected;isreadonly=true]false"
+      Write-Host "##vso[task.logissue type=error]High or Critical severity NuGet package vulnerabilities detected. The pipeline has been failed to ensure security incidents are resolved proactively."
+      Write-Host ""
+      Write-Host "The following packages have High or Critical severity vulnerabilities:"
+      Write-Host ""
+      $HighCriticalVulnerabilities | ForEach-Object {
+        $parts = $_ -split '\s+'
+        $packageName = $parts[1]
+        $advisoryUrl = $parts[-1]
+        $fixedVersion = Get-FixedVersion -AdvisoryUrl $advisoryUrl -PackageName $packageName
+        $fixText = if ($fixedVersion) { " (fix available: >= $fixedVersion)" } else { "" }
+        Write-Host "  $_$fixText"
+      }
+      Write-Host ""
+      Write-Host "Actions required:"
+      Write-Host "  1. Update the affected packages to a secure version"
+      Write-Host "  2. If no fix is available, assess the risk and consider alternative packages"
+      Write-Host "  3. Re-run the pipeline once the packages have been updated"
+      Write-Host ""
+      Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
+      Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
+      $(exit 1)
     }
-
-    if ($ErrorFound) {
+    elseif ($ErrorFound) {
       Write-Host "##vso[task.logissue type=warning]Package issues discovered, review output above"
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]true"
       $(exit 1)
-    } else {
+    }
+    else {
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
       $(exit 0)
     }
   displayName: Package Scanning
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
-
-- pwsh: |
-    $highCriticalDetails = Get-Content -Path "$env:AGENT_TEMPDIRECTORY/high-critical-vulnerabilities.txt"
-    Write-Host ""
-    Write-Host "##vso[task.logissue type=error]High or Critical severity NuGet package vulnerabilities detected. The pipeline has been failed to ensure security incidents are resolved proactively."
-    Write-Host ""
-    Write-Host "The following packages have High or Critical severity vulnerabilities:"
-    Write-Host ""
-    $highCriticalDetails | ForEach-Object { Write-Host "  $_" }
-    Write-Host ""
-    Write-Host "Actions required:"
-    Write-Host "  1. Update the affected packages to a secure version"
-    Write-Host "  2. If no fix is available, assess the risk and consider alternative packages"
-    Write-Host "  3. Re-run the pipeline once the packages have been updated"
-    Write-Host ""
-    Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
-    exit 1
-  displayName: Fail on High or Critical Severity Vulnerabilities
-  condition: and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey

--- a/azure-pipelines-templates/build/step/app-build.yml
+++ b/azure-pipelines-templates/build/step/app-build.yml
@@ -119,7 +119,7 @@ steps:
       Write-Output "##vso[task.setvariable variable=VulnerablePackagesDetected;isreadonly=true]false"
       $(exit 0)
     }
-  displayName: Package Scanning
+  displayName: Scan Packages
   continueOnError: ${{ parameters.ContinueOnVulnerablePackageScanError }}
 
 - pwsh: |
@@ -137,12 +137,12 @@ steps:
     Write-Host ""
     Write-Host "For more information, see https://devblogs.microsoft.com/dotnet/how-to-scan-nuget-packages-for-security-vulnerabilities/"
     exit 1
-  displayName: High/Critical Severity Vulnerabilities
+  displayName: Report Vulnerabilities
   condition: and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))
 
 - task: DownloadSecureFile@1
   name: DownloadDasGitHubAppPrivateKey
-  displayName: 'Download DAS GitHub App private key'
+  displayName: Download GitHub App Key
   inputs:
     secureFile: 'das-github-app-private-key.pem'
 

--- a/azure-pipelines-templates/build/step/gitversion.yml
+++ b/azure-pipelines-templates/build/step/gitversion.yml
@@ -3,12 +3,12 @@ parameters:
 
 steps:
 - task: gitversion/setup@0
-  displayName: gitversion/setup
+  displayName: GitVersion Setup
   inputs:
     versionSpec: 5.x
 
 - task: gitversion/execute@0
-  displayName: gitversion/execute
+  displayName: GitVersion Execute
   inputs:
     useConfigFile: true
     configFilePath: ${{ parameters.ConfigFilePath }}


### PR DESCRIPTION
## Context

The package scanning step in `app-build.yml` already runs `dotnet list package --vulnerable`, but it treats all severity levels equally — Low, Moderate, High, and Critical all produce the same warning. Repos like das-recruit set `ContinueOnVulnerablePackageScanError: true` which means even Critical vulnerabilities are swallowed as warnings and the pipeline passes.

This change enforces that **High and Critical severity vulnerabilities always fail the pipeline**, giving developers a clear, actionable error explaining why. Low and Medium severities continue to be controlled by the existing `ContinueOnVulnerablePackageScanError` parameter, preserving existing behaviour for those cases.

The key non-obvious thing: the enforcement is implemented as a **separate step** (with `continueOnError: false`) rather than inline logic in the scanning step. This is because `continueOnError` is a step-level property — you can't override it from within the script. A second step with its own `continueOnError: false` always runs (since `succeeded()` is true for `SucceededWithIssues`) and unconditionally fails the pipeline when High/Critical packages are found, regardless of what `ContinueOnVulnerablePackageScanError` is set to.

## Changes proposed in this pull request

**`azure-pipelines-templates/build/step/app-build.yml`**

- Modified **"Package Scanning"** step:
  - Added per-project `$Vulnerable = @()` initialisation to fix a pre-existing bug where the variable retained its value from the previous loop iteration when dotnet < 5
  - After the existing error check, added a filter for lines containing `>` that match `\b(High|Critical)\b` — these are collected into a list
  - High/Critical findings are written to `$env:AGENT_TEMPDIRECTORY/high-critical-vulnerabilities.txt` for the next step to read
  - Sets a new pipeline variable `HighCriticalVulnerabilitiesDetected` (`true`/`false`)

- Added new **"Fail on High or Critical Severity Vulnerabilities"** step:
  - Condition: `and(succeeded(), eq(variables['HighCriticalVulnerabilitiesDetected'], 'true'))`
  - No `continueOnError` (defaults to `false`) — pipeline **always** fails here regardless of `ContinueOnVulnerablePackageScanError`
  - Reads the temp file and outputs a clear error listing each affected package, the required actions, and a link to the NuGet security docs
  - Exits 1

## Guidance to review

**To verify the severity parsing logic:** the `dotnet list package --vulnerable` output prefixes each vulnerable package row with `>` and includes the severity as a word in that row, e.g.: