### PR TITLE
DASD-14381 Added minTlsCipherSuite parameter to enforce stricter security requirements for the App Service

### DIFF
--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -194,7 +194,7 @@
           "condition": "[parameters('deployStagingSlot')]",
           "name": "staging",
           "type": "slots",
-          "apiVersion": "2018-11-01",
+          "apiVersion": "2023-01-01",
           "location": "[resourceGroup().location]",
           "identity": {
             "type": "SystemAssigned"

--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -56,6 +56,13 @@
         "description": "Format removing backlashes: [{\"Name\": \"IP A\",\"ipAddress\": \"123.123.123.123\"},{\"Name\": \"IP B\",\"ipAddress\": \"234.234.234.234\"}]"
       }
     },
+    "minTlsCipherSuite": { 
+      "type": "string", 
+      "defaultValue": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 
+      "metadata": {
+        "description": "Specify the minimum TLS cipher suite to enforce for the App Service. Use this when you need stricter security requirements than the default."
+      }
+    },
     "appServiceSlotAppSettings": {
       "type": "secureObject",
       "defaultValue": {
@@ -148,7 +155,7 @@
     "useAppServiceSlotAppSettings": "[greater(length(parameters('appServiceSlotAppSettings').array), 0)]",
     "useAppServiceSlotConnectionStrings": "[greater(length(parameters('appServiceSlotConnectionStrings').array), 0)]",
     "useAppServiceStagingSlotAppSettingsCombined": "[union(parameters('appServiceSlotAppSettings').array, variables('appServiceStagingSlotAppSettings'))]",
-    "appServiceApiVersion": "2020-06-01",
+    "appServiceApiVersion": "2023‑01‑01",
     "appServiceProductionSlotAppSettingsCombined": "[union(parameters('appServiceAppSettings').array, variables('appServiceProductionSlotAppSettings'))]",
     "appServiceStagingSlotAppSettingsCombined": "[union(parameters('appServiceAppSettings').array, variables('appServiceStagingSlotAppSettings'))]"
     
@@ -175,6 +182,7 @@
           "virtualApplications": "[parameters('appServiceVirtualApplications')]",
           "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
           "minTlsVersion": "1.2",
+          "minTlsCipherSuite": "[parameters('minTlsCipherSuite')]",
           "ftpsState": "Disabled",
           "healthCheckPath": "[parameters('healthCheckPath')]"
         },
@@ -200,6 +208,7 @@
               "virtualApplications": "[parameters('appServiceVirtualApplications')]",
               "ipSecurityRestrictions": "[parameters('ipSecurityRestrictions')]",
               "minTlsVersion": "1.2",
+              "minTlsCipherSuite": "[parameters('minTlsCipherSuite')]",
               "ftpsState": "Disabled"
             },
             "httpsOnly": true

--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -155,7 +155,7 @@
     "useAppServiceSlotAppSettings": "[greater(length(parameters('appServiceSlotAppSettings').array), 0)]",
     "useAppServiceSlotConnectionStrings": "[greater(length(parameters('appServiceSlotConnectionStrings').array), 0)]",
     "useAppServiceStagingSlotAppSettingsCombined": "[union(parameters('appServiceSlotAppSettings').array, variables('appServiceStagingSlotAppSettings'))]",
-    "appServiceApiVersion": "2023‑01‑01",
+    "appServiceApiVersion": "2023-12-01",
     "appServiceProductionSlotAppSettingsCombined": "[union(parameters('appServiceAppSettings').array, variables('appServiceProductionSlotAppSettings'))]",
     "appServiceStagingSlotAppSettingsCombined": "[union(parameters('appServiceAppSettings').array, variables('appServiceStagingSlotAppSettings'))]"
     
@@ -194,7 +194,7 @@
           "condition": "[parameters('deployStagingSlot')]",
           "name": "staging",
           "type": "slots",
-          "apiVersion": "2023-01-01",
+          "apiVersion": "2023-12-01",
           "location": "[resourceGroup().location]",
           "identity": {
             "type": "SystemAssigned"

--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -58,7 +58,7 @@
     },
     "minTlsCipherSuite": { 
       "type": "string", 
-      "defaultValue": "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384", 
+      "defaultValue": "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", 
       "metadata": {
         "description": "Specify the minimum TLS cipher suite to enforce for the App Service. Use this when you need stricter security requirements than the default."
       }


### PR DESCRIPTION
## Context

This change updates the ARM template for the app service to support the minTlsCipherSuite property, which was not available in the older API version previously used. Updating the API version and parameterising the cipher suite ensures the setting is consistently deployed and controlled through infrastructure‑as‑code

## Changes proposed in this pull request

- Upgrade the Microsoft.Web/sites and slot resources to API version 2023‑12‑01 to support minTlsCipherSuite.
- Add a new parameter for minTlsCipherSuite so the value can be controlled per environment.
- Update siteConfig for both the main App Service and the staging slot to include the new property.


## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
