### PR TITLE
DASD-15189 - Add event-grid-malware-subscription template

### DIFF
--- a/templates/event-grid-malware-subscription.json
+++ b/templates/event-grid-malware-subscription.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "storageAccountName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the storage account that is the event source."
+            }
+        },
+        "functionAppName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the Function App that hosts the event handler."
+            }
+        },
+        "functionName": {
+            "type": "string",
+            "metadata": {
+                "description": "Name of the function (within the Function App) that handles MalwareScanningResult events."
+            }
+        },
+        "functionResourceGroup": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().name]",
+            "metadata": {
+                "description": "Resource group containing the Function App. Defaults to the current resource group."
+            }
+        },
+        "systemTopicName": {
+            "type": "string",
+            "defaultValue": "[concat(parameters('storageAccountName'), '-malware-topic')]"
+        },
+        "eventSubscriptionName": {
+            "type": "string",
+            "defaultValue": "malware-scan-sub"
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.EventGrid/systemTopics",
+            "apiVersion": "2022-06-15",
+            "name": "[parameters('systemTopicName')]",
+            "location": "[resourceGroup().location]",
+            "identity": {
+                "type": "SystemAssigned"
+            },
+            "properties": {
+                "source": "[resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName'))]",
+                "topicType": "Microsoft.Storage.StorageAccounts"
+            }
+        },
+        {
+            "type": "Microsoft.EventGrid/systemTopics/eventSubscriptions",
+            "apiVersion": "2022-06-15",
+            "name": "[concat(parameters('systemTopicName'), '/', parameters('eventSubscriptionName'))]",
+            "dependsOn": [
+                "[resourceId('Microsoft.EventGrid/systemTopics', parameters('systemTopicName'))]"
+            ],
+            "properties": {
+                "destination": {
+                    "endpointType": "AzureFunction",
+                    "properties": {
+                        "resourceId": "[resourceId(parameters('functionResourceGroup'), 'Microsoft.Web/sites/functions', parameters('functionAppName'), parameters('functionName'))]",
+                        "maxEventsPerBatch": 1,
+                        "preferredBatchSizeInKilobytes": 64
+                    }
+                },
+                "filter": {
+                    "includedEventTypes": [
+                        "Microsoft.Security.MalwareScanningResult"
+                    ]
+                },
+                "eventDeliverySchema": "EventGridSchema",
+                "retryPolicy": {
+                    "maxDeliveryAttempts": 30,
+                    "eventTimeToLiveInMinutes": 1440
+                }
+            }
+        }
+    ],
+    "outputs": {
+        "systemTopicName": {
+            "type": "string",
+            "value": "[parameters('systemTopicName')]"
+        },
+        "systemTopicResourceId": {
+            "type": "string",
+            "value": "[resourceId('Microsoft.EventGrid/systemTopics', parameters('systemTopicName'))]"
+        }
+    }
+}

--- a/templates/event-grid-malware-subscription.json
+++ b/templates/event-grid-malware-subscription.json
@@ -29,11 +29,84 @@
         },
         "systemTopicName": {
             "type": "string",
-            "defaultValue": "[concat(parameters('storageAccountName'), '-malware-topic')]"
+            "defaultValue": "[concat(parameters('storageAccountName'), '-malware-topic')]",
+            "metadata": {
+                "description": "Name of the Event Grid system topic to create for the storage account."
+            }
         },
         "eventSubscriptionName": {
             "type": "string",
-            "defaultValue": "malware-scan-sub"
+            "defaultValue": "malware-scan-sub",
+            "metadata": {
+                "description": "Name of the event subscription on the system topic."
+            }
+        },
+        "maxEventsPerBatch": {
+            "type": "int",
+            "defaultValue": 1,
+            "metadata": {
+                "description": "Maximum number of events to deliver per batch to the Azure Function."
+            }
+        },
+        "preferredBatchSizeInKilobytes": {
+            "type": "int",
+            "defaultValue": 64,
+            "metadata": {
+                "description": "Preferred batch size in kilobytes."
+            }
+        },
+        "maxDeliveryAttempts": {
+            "type": "int",
+            "defaultValue": 30,
+            "metadata": {
+                "description": "Maximum number of delivery retry attempts before an event is dead-lettered or dropped."
+            }
+        },
+        "eventTimeToLiveInMinutes": {
+            "type": "int",
+            "defaultValue": 1440,
+            "metadata": {
+                "description": "Time-to-live for events in minutes before they are dropped or dead-lettered."
+            }
+        },
+        "includedEventTypes": {
+            "type": "array",
+            "defaultValue": [
+                "Microsoft.Security.MalwareScanningResult"
+            ],
+            "metadata": {
+                "description": "Event types this subscription listens for."
+            }
+        },
+        "enableDeadLettering": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "Whether to enable dead-lettering of undelivered events to a storage blob container."
+            }
+        },
+        "deadLetterStorageAccountResourceId": {
+            "type": "string",
+            "defaultValue": "",
+            "metadata": {
+                "description": "Resource ID of the storage account used for dead-lettering. Required when enableDeadLettering is true."
+            }
+        },
+        "deadLetterContainerName": {
+            "type": "string",
+            "defaultValue": "malware-scan-deadletter",
+            "metadata": {
+                "description": "Name of the blob container used for dead-lettered events."
+            }
+        }
+    },
+    "variables": {
+        "deadLetterDestination": {
+            "endpointType": "StorageBlob",
+            "properties": {
+                "resourceId": "[parameters('deadLetterStorageAccountResourceId')]",
+                "blobContainerName": "[parameters('deadLetterContainerName')]"
+            }
         }
     },
     "resources": [
@@ -62,20 +135,19 @@
                     "endpointType": "AzureFunction",
                     "properties": {
                         "resourceId": "[resourceId(parameters('functionResourceGroup'), 'Microsoft.Web/sites/functions', parameters('functionAppName'), parameters('functionName'))]",
-                        "maxEventsPerBatch": 1,
-                        "preferredBatchSizeInKilobytes": 64
+                        "maxEventsPerBatch": "[parameters('maxEventsPerBatch')]",
+                        "preferredBatchSizeInKilobytes": "[parameters('preferredBatchSizeInKilobytes')]"
                     }
                 },
                 "filter": {
-                    "includedEventTypes": [
-                        "Microsoft.Security.MalwareScanningResult"
-                    ]
+                    "includedEventTypes": "[parameters('includedEventTypes')]"
                 },
                 "eventDeliverySchema": "EventGridSchema",
                 "retryPolicy": {
-                    "maxDeliveryAttempts": 30,
-                    "eventTimeToLiveInMinutes": 1440
-                }
+                    "maxDeliveryAttempts": "[parameters('maxDeliveryAttempts')]",
+                    "eventTimeToLiveInMinutes": "[parameters('eventTimeToLiveInMinutes')]"
+                },
+                "deadLetterDestination": "[if(parameters('enableDeadLettering'), variables('deadLetterDestination'), json('null'))]"
             }
         }
     ],


### PR DESCRIPTION
Adds a reusable building block that provisions an Event Grid system topic on a storage account and an event subscription filtering Microsoft.Security.MalwareScanningResult events to an Azure Function, so Defender for Storage malware-scan results can be handled (delete on Malicious, move on No threats found).

## Context

<!-- Why are you making this change? What might surprise someone about it? -->

Defender for Storage malware scanning emits results as Event Grid events on the storage account, but there is no out-of-the-box subscription wiring the results to a handler. Consumers currently have to hand-roll the system topic and subscription in every service that enables malware scanning, which leads to drift in retry policy, batching and dead-lettering behaviour across services. This template centralises that wiring so every service gets consistent, configurable delivery to the handler Function.

## Changes proposed in this pull request

<!-- If there are UI changes, please include Before and After screenshots. -->

Adds templates/event-grid-malware-subscription.json which provisions:

A Microsoft.EventGrid/systemTopics resource on the supplied storage account (topic type Microsoft.Storage.StorageAccounts) with a system-assigned managed identity.
A Microsoft.EventGrid/systemTopics/eventSubscriptions resource targeting an Azure Function, filtered to Microsoft.Security.MalwareScanningResult events, using the EventGridSchema delivery schema.


Exposes the following as parameters (all with sensible defaults so existing call sites are unaffected):

storageAccountName, functionAppName, functionName, functionResourceGroup — wiring inputs.
systemTopicName (default <storageAccountName>-malware-topic) and eventSubscriptionName (default malware-scan-sub).
maxEventsPerBatch (default 1) and preferredBatchSizeInKilobytes (default 64) — delivery batching.
maxDeliveryAttempts (default 30) and eventTimeToLiveInMinutes (default 1440) — retry policy.
includedEventTypes (default ["Microsoft.Security.MalwareScanningResult"]) — filter, kept overridable for future use.
enableDeadLettering (default false), deadLetterStorageAccountResourceId and deadLetterContainerName (default malware-scan-deadletter) — optional dead-lettering to a storage blob container. When enableDeadLettering is false, deadLetterDestination resolves to null and Event Grid treats the subscription as having no dead-letter destination.

Outputs systemTopicName and systemTopicResourceId for downstream role assignments / diagnostics.

## Guidance to review

<!-- How could someone else check this work? Which parts do you want more feedback on? -->

Confirm the API version (2022-06-15) for Microsoft.EventGrid/systemTopics and eventSubscriptions is acceptable against the building-blocks repo's existing conventions.
Sanity-check that Microsoft.Security.MalwareScanningResult is the correct event type for Defender for Storage on-upload scanning results (vs the older preview event names).
The deadLetterDestination is set via an if(...) expression that returns json('null') when disabled — please verify this is the agreed pattern in this repo for optional sub-objects rather than e.g. duplicating the resource under a condition.
Defaults (maxDeliveryAttempts: 30, eventTimeToLiveInMinutes: 1440, maxEventsPerBatch: 1) match what the AODP service was previously inlining; flag if any should be tuned lower as a platform-wide default.
Dead-lettering pre-req not handled by this template: when enableDeadLettering is true, the system topic's managed identity needs Storage Blob Data Contributor on the dead-letter storage account. This is intentionally left to the caller because the target storage account is consumer-defined; the systemTopicResourceId output is provided so callers can wire that role assignment themselves. Confirm this division of responsibility is acceptable, or push back and I'll add an optional role-assignment resource here.

## Things to check

- [ ] Has the CHANGELOG.md been updated?  This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message?  The later is essential for breaking changes.
