### PR TITLE
Add outbound VNet routing configuration

### DIFF
--- a/templates/app-service-v2.json
+++ b/templates/app-service-v2.json
@@ -187,7 +187,10 @@
           "healthCheckPath": "[parameters('healthCheckPath')]"
         },
         "httpsOnly": true,
-        "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]"
+        "vnetRouteAllEnabled": "[parameters('vnetRouteAllEnabled')]",
+        "outboundVnetRouting": {
+          "allTraffic": "[parameters('vnetRouteAllEnabled')]"
+        }
       },
       "resources": [
         {


### PR DESCRIPTION
This will support the new property outboundVnetRouting as shown in the microsoft docs here: [[Manage Azure App Service virtual network integration routing](https://learn.microsoft.com/en-us/azure/app-service/configure-vnet-integration-routing)

Tested in PP here: [Pipeline Run](https://dev.azure.com/sfa-gov-uk/Digital%20Apprenticeship%20Service/_build/results?buildId=1097929&view=logs&j=529a16a5-3725-5ed3-156e-75db310a031e&t=0e189b55-9f8a-5397-d068-a0d6ac330cc9)