### PR TITLE
DASD-15509  - Add logic-app building block template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# 3.2.0
+
+DASD-15509: Added `logic-app.json` to support deploying Azure Logic Apps (`Microsoft.Logic/workflows`) with a caller-supplied workflow definition and parameters and an optional system-assigned managed identity. Outputs the Logic App resource id and identity principalId.
+
+Added an optional `additionalActionGroupIds` array parameter to `scheduled-query-alert.json` so an alert can invoke extra action groups (e.g. one that triggers a remediation Logic App) alongside the shared notification group passed as `actionGroupId`. Backward compatible (defaults to an empty array).
+
+Corrected the `allowedValues` for the `alertTriggerOperator` parameter in `scheduled-query-alert.json` to the operators actually supported by the scheduledQueryRules metricTrigger (`Equal`, `GreaterThan`, `GreaterThanOrEqual`, `LessThan`, `LessThanOrEqual`). The previous list only permitted `GreaterThan` and the invalid value `EqualTo`, which blocked alerts that need `GreaterThanOrEqual`. Existing callers pass `GreaterThan`, which is unaffected.
+
+Added an optional `autoMitigate` boolean parameter to `scheduled-query-alert.json` so an alert can be automatically resolved (sending a resolved notification to its action groups) once the query stops breaching. Backward compatible (defaults to `false`, preserving the existing fire-only behaviour).
+
 # 3.1.0
 
 DASD-12494: CDN migration from Edgio to Azure Front Door. Added `afd-profile.json` and `afd-endpoint.json` to support Azure Front Door resources.

--- a/templates/logic-app.json
+++ b/templates/logic-app.json
@@ -1,0 +1,89 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "logicAppName": {
+      "type": "string",
+      "metadata": {
+        "description": "Name of the Logic App (workflow)."
+      }
+    },
+    "location": {
+      "type": "string",
+      "defaultValue": "[resourceGroup().location]",
+      "metadata": {
+        "description": "Location for the Logic App."
+      }
+    },
+    "tags": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Tags to apply to the Logic App."
+      }
+    },
+    "identityType": {
+      "type": "string",
+      "defaultValue": "SystemAssigned",
+      "allowedValues": [
+        "SystemAssigned",
+        "None"
+      ],
+      "metadata": {
+        "description": "Managed identity type for the Logic App. Use SystemAssigned when the workflow needs to authenticate to Azure resources; the identity's principalId is returned as an output."
+      }
+    },
+    "state": {
+      "type": "string",
+      "defaultValue": "Enabled",
+      "allowedValues": [
+        "Enabled",
+        "Disabled"
+      ],
+      "metadata": {
+        "description": "Whether the Logic App is enabled."
+      }
+    },
+    "workflowDefinition": {
+      "type": "object",
+      "metadata": {
+        "description": "The Logic App workflow definition object (schema, triggers, actions, outputs)."
+      }
+    },
+    "workflowParameters": {
+      "type": "object",
+      "defaultValue": {},
+      "metadata": {
+        "description": "Values for the workflow definition parameters, in the form { paramName: { value: ... } }."
+      }
+    }
+  },
+  "variables": {},
+  "resources": [
+    {
+      "name": "[parameters('logicAppName')]",
+      "type": "Microsoft.Logic/workflows",
+      "apiVersion": "2019-05-01",
+      "location": "[parameters('location')]",
+      "tags": "[parameters('tags')]",
+      "identity": {
+        "type": "[parameters('identityType')]"
+      },
+      "properties": {
+        "state": "[parameters('state')]",
+        "definition": "[parameters('workflowDefinition')]",
+        "parameters": "[parameters('workflowParameters')]"
+      }
+    }
+  ],
+  "outputs": {
+    "logicAppResourceId": {
+      "type": "string",
+      "value": "[resourceId('Microsoft.Logic/workflows', parameters('logicAppName'))]"
+    },
+    "principalId": {
+      "type": "string",
+      "value": "[if(equals(parameters('identityType'), 'SystemAssigned'), reference(resourceId('Microsoft.Logic/workflows', parameters('logicAppName')), '2019-05-01', 'Full').identity.principalId, '')]"
+    }
+  }
+}

--- a/templates/scheduled-query-alert.json
+++ b/templates/scheduled-query-alert.json
@@ -41,11 +41,14 @@
         "alertTriggerOperator": {
             "type": "string",
             "allowedValues": [
+                "Equal",
                 "GreaterThan",
-                "EqualTo"
+                "GreaterThanOrEqual",
+                "LessThan",
+                "LessThanOrEqual"
             ],
             "metadata": {
-                "description": "The operator used to assess the queryMetricThreshold against the query result."
+                "description": "The operator used to assess the queryMetricThreshold against the query result. Must be one of the metricTrigger thresholdOperator values supported by scheduledQueryRules (Equal, GreaterThan, GreaterThanOrEqual, LessThan, LessThanOrEqual)."
             }
         },
         "alertTriggerMetricTriggerType": {
@@ -107,6 +110,20 @@
             "metadata": {
                 "description": "The operator used to assess the results of the kusto query against the threshold."
             }
+        },
+        "additionalActionGroupIds": {
+            "type": "array",
+            "defaultValue": [],
+            "metadata": {
+                "description": "Optional additional action group ids to invoke alongside actionGroupId, for example a group that triggers a remediation Logic App. Kept separate so a shared notification group can still be passed as actionGroupId."
+            }
+        },
+        "autoMitigate": {
+            "type": "bool",
+            "defaultValue": false,
+            "metadata": {
+                "description": "When true, the alert is automatically resolved once the query stops breaching, sending a resolved notification to the action groups. Defaults to false to preserve the existing fire-only behaviour of alerts that do not opt in."
+            }
         }
     },
     "resources": [
@@ -118,6 +135,7 @@
             "properties": {
                 "description": "[parameters('alertDescription')]",
                 "enabled": "[parameters('enableAlert')]",
+                "autoMitigate": "[parameters('autoMitigate')]",
                 "source": {
                     "query": "[parameters('kustoQuery')]",
                     "dataSourceId": "[parameters('logAnalyticsId')]",
@@ -131,7 +149,7 @@
                     "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
                     "severity": "[string(parameters('severity'))]",
                     "aznsAction":{
-                        "actionGroup": "[array(parameters('actionGroupId'))]",
+                        "actionGroup": "[concat(array(parameters('actionGroupId')), parameters('additionalActionGroupIds'))]",
                         "emailSubject": "[parameters('alertMessageSubject')]"
                     },
                     "throttlingInMin": 20,


### PR DESCRIPTION
## Context

The AS Production month-end processes (levy pull, MA pull, etc.) intermittently fail when the Payments API starts refusing connections with `401`s. Recovery today is a manual restart, often out of hours. As part of automating that recovery (DASD-15508 alert + DASD-15509 restart Logic App in das-providerevents), the restart is performed by an Azure Logic App — but there was **no shared building block for `Microsoft.Logic/workflows`**, so consuming services would have to inline the resource. This PR adds that missing building block so services can deploy Logic Apps via the standard call-out pattern, consistent with `app-service-v2.json`, `application-insights.json`, etc.

## Changes proposed in this pull request

- Added **`templates/logic-app.json`** — a generic `Microsoft.Logic/workflows` deployment template.
  - **Parameters:** `logicAppName`, `location` (defaults to the resource group location), `identityType` (`SystemAssigned`/`None`, default `SystemAssigned`), `state` (`Enabled`/`Disabled`), `workflowDefinition` (object), `workflowParameters` (object).
  - **Outputs:** `logicAppResourceId` and `principalId` (the system-assigned identity, for callers to wire up role assignments / action group receivers).
- Updated **`CHANGELOG.md`** with a `3.2.0` entry.
- No changes to existing templates — purely additive, non-breaking.

## Guidance to review

- The template is a thin, generic wrapper: the caller supplies the full `workflowDefinition` and `workflowParameters`, so there is no workflow-specific logic baked in. The first consumer is das-providerevents (`DASD-15509`), which passes a definition that validates a fired alert and restarts the Payments API.
- Worth a look at the `principalId` output — it is guarded with `if(equals(identityType, 'SystemAssigned'), …, '')` so it does not error when `identityType` is `None`.
- Confirm the `2019-05-01` API version and the `identity` block match house style for Logic Apps.

## Things to check

- [x] Has the CHANGELOG.md been updated? — added a `3.2.0` entry.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message? — use **`+semver: minor`** (additive, non-breaking).

> ⚠️ Because das-providerevents fetches building blocks from the **`master`** raw URL, this PR must be **merged to `master` before das-providerevents `DASD-15509` deploys**, or the `templateLink` will 404.