### PR TITLE
DASD-15509 - FIX for autoMitage property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2.1
+
+DASD-15508: Fixed `scheduled-query-alert.json` so the `throttlingInMin` (action suppression) property is omitted entirely when `autoMitigate` is `true`. Azure rejects a scheduledQueryRule that has both auto-mitigation and action suppression set ("Auto mitigation must be disabled when action suppression is set"), and setting the throttle to 0 is not sufficient - the property must be absent. The action object is now built with `union()` so alerts that do not opt into `autoMitigate` keep the previous 20 minute throttle, leaving existing behaviour unchanged.
+
 # 3.2.0
 
 DASD-15509: Added `logic-app.json` to support deploying Azure Logic Apps (`Microsoft.Logic/workflows`) with a caller-supplied workflow definition and parameters and an optional system-assigned managed identity. Outputs the Logic App resource id and identity principalId.

--- a/templates/scheduled-query-alert.json
+++ b/templates/scheduled-query-alert.json
@@ -126,6 +126,25 @@
             }
         }
     },
+    "variables": {
+        "alertActionBase": {
+            "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
+            "severity": "[string(parameters('severity'))]",
+            "aznsAction": {
+                "actionGroup": "[concat(array(parameters('actionGroupId')), parameters('additionalActionGroupIds'))]",
+                "emailSubject": "[parameters('alertMessageSubject')]"
+            },
+            "trigger": {
+                "thresholdOperator": "[parameters('queryMetricThresholdOperator')]",
+                "threshold": "[parameters('queryMetricThreshold')]",
+                "metricTrigger": {
+                    "thresholdOperator": "[parameters('alertTriggerOperator')]",
+                    "threshold": "[parameters('alertTriggerThreshold')]",
+                    "metricTriggerType": "[parameters('alertTriggerMetricTriggerType')]"
+                }
+            }
+        }
+    },
     "resources": [
         {
             "type": "microsoft.insights/scheduledQueryRules",
@@ -145,24 +164,7 @@
                     "frequencyInMinutes": "[parameters('alertFrequency')]",
                     "timeWindowInMinutes": "[parameters('alertPeriod')]"
                 },
-                "action": {
-                    "odata.type": "Microsoft.WindowsAzure.Management.Monitoring.Alerts.Models.Microsoft.AppInsights.Nexus.DataContracts.Resources.ScheduledQueryRules.AlertingAction",
-                    "severity": "[string(parameters('severity'))]",
-                    "aznsAction":{
-                        "actionGroup": "[concat(array(parameters('actionGroupId')), parameters('additionalActionGroupIds'))]",
-                        "emailSubject": "[parameters('alertMessageSubject')]"
-                    },
-                    "throttlingInMin": 20,
-                    "trigger":{
-                        "thresholdOperator": "[parameters('queryMetricThresholdOperator')]",
-                        "threshold": "[parameters('queryMetricThreshold')]",
-                        "metricTrigger":{
-                            "thresholdOperator": "[parameters('alertTriggerOperator')]",
-                            "threshold": "[parameters('alertTriggerThreshold')]",
-                            "metricTriggerType": "[parameters('alertTriggerMetricTriggerType')]"
-                        }
-                    }
-                }
+                "action": "[union(variables('alertActionBase'), if(parameters('autoMitigate'), json('{}'), json('{\"throttlingInMin\": 20}')))]"
             }
         }
     ]


### PR DESCRIPTION
## Context

The Payments API 401 spike log-search alert (das-monitoring) opts into `autoMitigate`
so it raises a Resolved notification once the 401s clear. Azure refuses to create a
`scheduledQueryRules` alert that has **both** auto-mitigation and action suppression
enabled — deployment failed with *"Auto mitigation must be disabled when action
suppression is set."* This building block hard-coded `throttlingInMin: 20` (the
suppression), so any alert using `autoMitigate` could not deploy.

The surprising part: setting `throttlingInMin` to `0` is **not** sufficient — Azure
treats the property simply being present as suppression, so it has to be omitted entirely.

## Changes proposed in this pull request

- `scheduled-query-alert.json`: the `action` object is now assembled with `union()` so
  `throttlingInMin` is **omitted** when `autoMitigate` is `true`, and kept at `20`
  minutes otherwise. Alerts that don't opt into `autoMitigate` (KeyVault certificate
  renewal, SQL DTU) are unchanged.
- `CHANGELOG.md`: bumped to `3.2.1`.

## Guidance to review

- The key change is the expression
  `union(variables('alertActionBase'), if(parameters('autoMitigate'), json('{}'), json('{"throttlingInMin": 20}')))`
  — confirm it drops the property only when `autoMitigate` is true.
- Tested end-to-end against PreProd via the das-monitoring `DASD-15508` pipeline: the
  payments alert (`autoMitigate: true`) now deploys cleanly with auto-resolve on and no
  throttle; the KeyVault/DTU alerts (`autoMitigate: false`) still deploy with the
  20-minute throttle.

## Things to check

- [x] Has the CHANGELOG.md been updated? This is essential for breaking changes.
- [ ] Has `+semver: minor` or `+semver: major` been included in the merge commit message? The later is essential for breaking changes.
      <!-- Not required here: this is a backward-compatible bug fix (patch). GitVersion increments patch by default. -->