### PR TITLE
DASD-15189 - Declare blob index tagging and move Defender for Storage to the GA API

### DIFF
--- a/templates/defender-for-storage.json
+++ b/templates/defender-for-storage.json
@@ -24,6 +24,14 @@
         "scanResultsEventGridTopicResourceId": {
             "type": "string",
             "defaultValue": ""
+        },
+        "blobScanResultsOptions": {
+            "type": "string",
+            "defaultValue": "blobIndexTags",
+            "allowedValues": [
+                "blobIndexTags",
+                "None"
+            ]
         }
     },
     "variables": {
@@ -31,12 +39,13 @@
             "onUpload": {
                 "isEnabled": "[parameters('enableOnUploadMalwareScanning')]",
                 "capGBPerMonth": "[parameters('capGBPerMonth')]"
-            }
+            },
+            "blobScanResultsOptions": "[parameters('blobScanResultsOptions')]"
         }
     },
     "resources": [
         {
-            "apiVersion": "2022-12-01-preview",
+            "apiVersion": "2025-06-01",
             "name": "current",
             "type": "Microsoft.Security/DefenderForStorageSettings",
             "properties": {


### PR DESCRIPTION
Malware scan results are consumed either as a **blob index tag** or as an **Event Grid message**. The tag was being relied on implicitly, because Defender writes it by default — but nothing declared it, so it was an undeclared service default rather than configuration.

## Changes

- Adds `blobScanResultsOptions`, defaulting to `blobIndexTags`, which is the service default. **Existing consumers render identically and are unaffected.**
- Bumps the resource from `2022-12-01-preview` to `2025-06-01`. The property only exists from `2025-02-01-preview` onward, so the bump is required to declare it.

## Why 2025-06-01

It is the **GA** version, not a preview, and moves this template off a preview API that is now three years old.

Verified against the [resource schema](https://learn.microsoft.com/azure/templates/microsoft.security/2025-06-01/defenderforstoragesettings) that it carries every property already in use here, so nothing else changes:

| Property | In 2025-06-01 |
|---|---|
| `isEnabled` | yes |
| `malwareScanning.onUpload.isEnabled` | yes |
| `malwareScanning.onUpload.capGBPerMonth` | yes |
| `malwareScanning.scanResultsEventGridTopicResourceId` | yes |
| `sensitiveDataDiscovery.isEnabled` | yes |
| `overrideSubscriptionLevelSettings` | yes |

## Notes for consumers

- On storage accounts with **hierarchical namespaces** enabled, index tags require the "Blob Tags for Hierarchical Namespace" preview to be opted into. Pass `blobScanResultsOptions: None` if it isn't.
- Index tags are **not tamper-resistant** — anyone with permission to modify tags can alter them. Per [Microsoft's guidance](https://learn.microsoft.com/azure/defender-for-cloud/introduction-malware-scanning#malware-scan-results) they should not be used as a sole security control; security-sensitive workflows should use the Event Grid scan result events, alerts, or Log Analytics.

The only consumer found across the repos checked is das-aodp-api, which needs no change — the default preserves current behaviour.